### PR TITLE
validate if order_item is empty before build product_items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.1 - 12/05/2015
+- Correção do bug not_found para assinaturas com frete desabilitado.
+
 # 1.0.0 - 27/04/2015
 - Adicionado suporte a produtos e assinaturas variáveis
 - Correção da exibição de planos anuais

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -340,7 +340,7 @@ class Vindi_Payment
             $order_items[$key]['vindi_id'] = $product->vindi_id;
             $order_items[$key]['price']    = (float) $product->get_price();
         }
-        
+
         return $order_items;
     }
 
@@ -400,6 +400,11 @@ class Vindi_Payment
     protected function build_product_items_for_subscription($order_item)
     {
         $product_items  = [];
+
+        if(empty($order_item)) {
+            return $product_items;
+        }
+
         $total_discount = $this->order->get_total_discount();
 
         if(!empty($total_discount) && $order_item['type'] == 'product') {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.0
 Tested up to: 4.4
-Stable Tag: 1.0.0
+Stable Tag: 1.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+
+= 1.0.1 - 12/05/2015 =
+- Correção do bug not_found para assinaturas com frete desabilitado.
 
 = 1.0.0 - 27/04/2015 =
 - Adicionado suporte a produtos e assinaturas variáveis

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 1.0.0
+* Version: 1.0.1
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.0
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '1.0.0';
+		const VERSION = '1.0.1';
 
         /**
 		 * @var string


### PR DESCRIPTION
MOD-17
Adiciona uma validação para evitar que assinaturas sem frete tenham problemas na hora do checkout. Quando o frete é desabilitado por completo no WC, o método que monta o product_items  para as assinaturas estava criando o item referente a ele com os atributos nulos.
