### PR TITLE
fix installment for single orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.2 - 08/06/2015
+- Correção do bug de parcelamento para faturas avulsas.
+
 # 1.0.1 - 12/05/2015
 - Correção do bug not_found para assinaturas com frete desabilitado.
 - Atualização de informações do usuário na Vindi pela Área do Cliente no WooCommerce Subscriptions.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.0
 Tested up to: 4.4
-Stable Tag: 1.0.1
+Stable Tag: 1.0.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+
+= 1.0.2 - 08/06/2015 =
+- Correção do bug de parcelamento para faturas avulsas.
 
 = 1.0.1 - 12/05/2015 =
 - Correção do bug not_found para assinaturas com frete desabilitado.

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 1.0.1
+* Version: 1.0.2
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.0
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '1.0.1';
+		const VERSION = '1.0.2';
 
         /**
 		 * @var string


### PR DESCRIPTION
MOD-18
Corrige o bug de parcelamento para compras avulsas. Quando a parcelamento estava configurado, cliente que compravam produtos com o preço abaixo da parcela mínima tinha problemas na hora do checkout. A caixa de seleção que deveria estar com o valor de uma parcela à vista ficava em branco.
