### PR TITLE
Fix/cancel subscription

### DIFF
--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -198,6 +198,19 @@ class Vindi_API
     }
 
     /**
+     * @param int   $bill_id
+     *
+     * @return array|bool|mixed
+     */
+    public function delete_bill($bill_id)
+    {
+        if ($response = $this->request('bills/' . $bill_id, 'DELETE'))
+            return $response;
+
+        return false;
+    }
+
+    /**
      * @param string $code
      *
      * @return array|bool|mixed
@@ -347,7 +360,7 @@ class Vindi_API
     public function create_bill($body)
     {
         if ($response = $this->request('bills', 'POST', $body)) {
-            return $response['bill']['id'];
+            return $response['bill'];
         }
 
         return false;

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -255,16 +255,17 @@ class Vindi_Payment
         $wc_subscriptions = wcs_get_subscriptions_for_order($this->order);
         $wc_subscription  = end($wc_subscriptions);
 
-        if ($message = $this->cancel_if_denied_bill_status($subscription['bill'])) {
-            $this->container->api->delete_subscription($subscription['id'], true);
-            $this->order->update_status('cancelled', __($message, VINDI_IDENTIFIER));
-            $this->abort(__($message, VINDI_IDENTIFIER), true);
-        }
-
         add_post_meta($this->order->id, 'vindi_wc_cycle', $subscription['current_period']['cycle']);
         add_post_meta($this->order->id, 'vindi_wc_subscription_id', $subscription['id']);
         add_post_meta($this->order->id, 'vindi_wc_bill_id', $subscription['bill']['id']);
         add_post_meta($wc_subscription->id, 'vindi_wc_subscription_id', $subscription['id']);
+
+        if ($message = $this->cancel_if_denied_bill_status($subscription['bill'])) {
+            $wc_subscription->update_status('cancelled', __($message, VINDI_IDENTIFIER));
+            $this->order->update_status('cancelled', __($message, VINDI_IDENTIFIER));
+            $this->abort(__($message, VINDI_IDENTIFIER), true);
+        }
+
         $this->add_download_url_meta_for_subscription($subscription);
 
         return $this->finish_payment($subscription['bill']);

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -243,13 +243,19 @@ class Vindi_Payment
         $wc_subscriptions = wcs_get_subscriptions_for_order($this->order);
         $wc_subscription  = end($wc_subscriptions);
 
+        if ($message = $this->cancel_if_denied_bill_status($subscription['bill'])) {
+            $this->container->api->delete_subscription($subscription['id'], true);
+            $this->order->update_status('cancelled', __($message, VINDI_IDENTIFIER));
+            $this->abort(__($message, VINDI_IDENTIFIER), true);
+        }
+
         add_post_meta($this->order->id, 'vindi_wc_cycle', $subscription['current_period']['cycle']);
         add_post_meta($this->order->id, 'vindi_wc_subscription_id', $subscription['id']);
         add_post_meta($this->order->id, 'vindi_wc_bill_id', $subscription['bill']['id']);
         add_post_meta($wc_subscription->id, 'vindi_wc_subscription_id', $subscription['id']);
         $this->add_download_url_meta_for_subscription($subscription);
 
-        return $this->finish_payment();
+        return $this->finish_payment($subscription['bill']);
     }
 
     /**
@@ -259,11 +265,18 @@ class Vindi_Payment
     public function process_single_payment()
     {
         $customer_id = $this->get_customer();
-        $bill_id     = $this->create_bill($customer_id);
-        add_post_meta($this->order->id, 'vindi_wc_bill_id', $bill_id);
-        $this->add_download_url_meta_for_single_payment($bill_id);
+        $bill        = $this->create_bill($customer_id);
 
-        return $this->finish_payment();
+        if($message = $this->cancel_if_denied_bill_status($bill)) {
+            $this->container->api->delete_bill($bill['id']);
+            $this->order->update_status('cancelled', __($message, VINDI_IDENTIFIER));
+            $this->abort(__($message, VINDI_IDENTIFIER), true);
+        }
+
+        add_post_meta($this->order->id, 'vindi_wc_bill_id', $bill['id']);
+        $this->add_download_url_meta_for_single_payment($bill['id']);
+
+        return $this->finish_payment($bill);
     }
 
     /**
@@ -540,20 +553,45 @@ class Vindi_Payment
             add_post_meta($this->order->id, 'vindi_wc_invoice_download_url', $download_url);
     }
 
+    protected function cancel_if_denied_bill_status($bill)
+    {
+        if(empty($bill['charges'])) {
+            return false;
+        }
+
+        $last_charge        = end($bill['charges']);
+        $transaction_status = $last_charge['last_transaction']['status'];
+        $denied_status      = [
+            'rejected' => 'Infelizmente não foi possível autorizar seu pagamento.',
+            'failure'  => 'Ocorreu um erro ao aprovar a transação, tente novamente.'
+        ];
+
+        if(array_key_exists($transaction_status, $denied_status)) {
+            return $denied_status[$transaction_status];
+        }
+
+        return false;
+    }
+
     /**
      * @return array
      */
-    protected function finish_payment()
+    protected function finish_payment($bill)
     {
         $this->container->woocommerce->cart->empty_cart();
 
-        $data_to_log    = sprintf('Aguardando confirmação de recebimento do pedido %s pela Vindi.', $this->order->id);
-        $status_message = __('Aguardando confirmação de recebimento do pedido pela Vindi.', VINDI_IDENTIFIER);
-        $status         = 'pending';
+        if($bill['status'] == 'paid') {
+            $status         = $this->container->get_return_status();
+            $status_message = __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI_IDENTIFIER);
+        } else {
+            $data_to_log    = sprintf('Aguardando confirmação de recebimento do pedido %s pela Vindi.', $this->order->id);
+            $status_message = __('Aguardando confirmação de recebimento do pedido pela Vindi.', VINDI_IDENTIFIER);
+            $status         = 'pending';
 
-        if (! $this->is_cc()) {
-            $data_to_log    = sprintf('Aguardando pagamento do boleto do pedido %s.', $this->order->id);
-            $status_message = __('Aguardando pagamento do boleto do pedido', VINDI_IDENTIFIER);
+            if (! $this->is_cc()) {
+                $data_to_log    = sprintf('Aguardando pagamento do boleto do pedido %s.', $this->order->id);
+                $status_message = __('Aguardando pagamento do boleto do pedido', VINDI_IDENTIFIER);
+            }
         }
 
         $this->container->logger->log($data_to_log);

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -606,14 +606,9 @@ class Vindi_Payment
             $status         = $this->container->get_return_status();
             $status_message = __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI_IDENTIFIER);
         } else {
-            $data_to_log    = sprintf('Aguardando confirmação de recebimento do pedido %s pela Vindi.', $this->order->id);
-            $status_message = __('Aguardando confirmação de recebimento do pedido pela Vindi.', VINDI_IDENTIFIER);
+            $data_to_log    = sprintf('Aguardando pagamento do pedido %s pela Vindi.', $this->order->id);
+            $status_message = __('Aguardando pagamento do pedido.', VINDI_IDENTIFIER);
             $status         = 'pending';
-
-            if (! $this->is_cc()) {
-                $data_to_log    = sprintf('Aguardando pagamento do boleto do pedido %s.', $this->order->id);
-                $status_message = __('Aguardando pagamento do boleto do pedido', VINDI_IDENTIFIER);
-            }
         }
 
         $this->container->logger->log($data_to_log);

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -101,17 +101,17 @@ class Vindi_Settings extends WC_Settings_API
 				'description'      => sprintf(__('Envia informações de RG e Inscrição Estadual para Emissão de NFe\'s com nossos parceiros. %s', VINDI_IDENTIFIER), $nfe_know_more),
 				'default'          => 'no',
 			),
-			// 'return_status'        => array(
-			// 	'title'            => __('Status de conclusão do pedido', VINDI_IDENTIFIER),
-			// 	'type'             => 'select',
-			// 	'description'      => __('Status que o pedido deverá ter após receber a confirmação de pagamento da Vindi.', VINDI_IDENTIFIER),
-			// 	'default'          => 'processing',
-			// 	'options'          => array(
-			// 		'processing'   => 'Processando',
-			// 		'on-hold'      => 'Aguardando',
-			// 		'completed'    => 'Concluído',
-			// 	),
-			// ),
+			'return_status'        => array(
+				'title'            => __('Status de conclusão do pedido', VINDI_IDENTIFIER),
+				'type'             => 'select',
+				'description'      => __('Status que o pedido deverá ter após receber a confirmação de pagamento da Vindi.', VINDI_IDENTIFIER),
+				'default'          => 'processing',
+				'options'          => array(
+					'processing'   => 'Processando',
+					'on-hold'      => 'Aguardando',
+					'completed'    => 'Concluído',
+				),
+			),
 			'testing'              => array(
 				'title'            => __('Testes', 'vindi-woocommerce'),
 				'type'             => 'title',
@@ -143,6 +143,19 @@ class Vindi_Settings extends WC_Settings_API
     public function get_api_key()
     {
         return $this->settings['api_key'];
+    }
+
+    /**
+     * Get Return Status
+     * @return string
+     **/
+    public function get_return_status()
+    {
+        if(isset($this->settings['return_status'])) {
+            return $this->settings['return_status'];
+        } else {
+            return 'processing';
+        }
     }
 
     /**

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -84,11 +84,13 @@ class Vindi_Webhook_Handler
      **/
     private function period_created($data)
     {
-        $cycle           = $data->period->cycle;
-        $subscription    = $this->find_subscription_by_id($data->period->subscription->code);
+        $cycle                 = $data->period->cycle;
+        $subscription          = $this->find_subscription_by_id($data->period->subscription->code);
+        $vindi_subscription_id = $data->period->subscription->id;
 
-        if($this->subscription_has_order_in_cycle($subscription->id, $cycle))
-            throw new Exception('Já existe o ciclo $cycle para a assinatura ' . $data->period->subscription->id . ' pedido ' . $subscription->id);
+        if($this->subscription_has_order_in_cycle($vindi_subscription_id, $cycle)) {
+            throw new Exception('Já existe o ciclo $cycle para a assinatura ' . $vindi_subscription_id . ' pedido ' . $subscription->id);
+        }
 
         WC_Subscriptions_Manager::prepare_renewal($subscription->id);
         $order_id = $subscription->get_last_order();

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -23,7 +23,7 @@ class Vindi_Webhook_Handler
         $token    = filter_input(INPUT_GET, 'token', FILTER_SANITIZE_STRING);
         $raw_body = file_get_contents('php://input');
         $body     = json_decode($raw_body);
-        
+
         if(!$this->validate_access_token($token))
             die('invalid access token');
 
@@ -132,8 +132,8 @@ class Vindi_Webhook_Handler
             $order                 = $this->find_order_by_subscription_and_cycle($vindi_subscription_id, $cycle);
         }
 
-        $order->payment_complete();
-        $order->add_order_note('Nova confirmação de pagamento!');
+        $new_status = $this->container->get_return_status();
+        $order->update_status($new_status, __('O Pagamento foi realizado com sucesso pela Vindi.', 'woocommerce-vindi'));
     }
 
     /**


### PR DESCRIPTION
Corrige alguns problema relacionados os tipos de status de cancelamento nas assinatura do WC:
- Adiciona o cancelamento de assinaturas caso ocorra problemas no checkout.
- Corrige o método que verifica qual ciclo a Order pertence dentro do evento period_created dos webhooks.
- Adicionar a opção de escolha para quais status as Orders irão caso o pagamento seja efetuado com sucesso.
- Trata o status pending-cancel para dar suporte a outros plugins que fazem gestão de acesso para algumas áreas do WC.
