### PR TITLE
Renovação de períodos - WooCommerce [DEV-219]

### DIFF
--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -106,7 +106,6 @@ class Vindi_Webhook_Handler
     private function bill_created($data)
     {
         if($data->bill->subscription) {
-
             $this->subscription_renew($data);
 
             $wc_subscription_id    = $data->bill->subscription->code;

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -84,7 +84,6 @@ class Vindi_Webhook_Handler
      **/
     private function subscription_renew($data)
     {
-
         $cycle                 = $data->bill->period->cycle;
         $subscription          = $this->find_subscription_by_id($data->bill->subscription->code);
         $vindi_subscription_id = $data->bill->subscription->id;
@@ -106,7 +105,6 @@ class Vindi_Webhook_Handler
      **/
     private function bill_created($data)
     {
-
         if($data->bill->subscription) {
 
             $this->subscription_renew($data);
@@ -121,7 +119,6 @@ class Vindi_Webhook_Handler
 
             add_post_meta($order->id, 'vindi_wc_bill_id', $data->bill->id);
         }
-
     }
 
     /**

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -82,11 +82,12 @@ class Vindi_Webhook_Handler
      * Process period_created event from webhook
      * @param $data array
      **/
-    private function period_created($data)
+    private function subscription_renew($data)
     {
-        $cycle                 = $data->period->cycle;
-        $subscription          = $this->find_subscription_by_id($data->period->subscription->code);
-        $vindi_subscription_id = $data->period->subscription->id;
+
+        $cycle                 = $data->bill->period->cycle;
+        $subscription          = $this->find_subscription_by_id($data->bill->subscription->code);
+        $vindi_subscription_id = $data->bill->subscription->id;
 
         if($this->subscription_has_order_in_cycle($vindi_subscription_id, $cycle)) {
             throw new Exception('Já existe o ciclo $cycle para a assinatura ' . $vindi_subscription_id . ' pedido ' . $subscription->id);
@@ -105,7 +106,11 @@ class Vindi_Webhook_Handler
      **/
     private function bill_created($data)
     {
+
         if($data->bill->subscription) {
+
+            $this->subscription_renew($data);
+
             $wc_subscription_id    = $data->bill->subscription->code;
             $vindi_subscription_id = $data->bill->subscription->id;
             $cycle                 = $data->bill->period->cycle;
@@ -116,6 +121,7 @@ class Vindi_Webhook_Handler
 
             add_post_meta($order->id, 'vindi_wc_bill_id', $data->bill->id);
         }
+
     }
 
     /**


### PR DESCRIPTION
Esta atualização faz com que a criação de períodos no Woocommerce seja feita através do bill_created.
