### PR TITLE
Ajuste na comunicação com a API [DEV-295]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2.1 - 10/10/2016
 - Ajustes no problema de comunicação com a API da Vindi.
+- Alterando o tempo de cache dos métodos de pagamento para 1 hora.
 
 # 1.2.0 - 05/10/2016
 - Alterada a forma de renovação dos pedidos se baseando no evento bill_created da Vindi.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.1 - 10/10/2016
+- Ajustes no problema de comunicação com a API da Vindi.
+
 # 1.2.0 - 05/10/2016
 - Alterada a forma de renovação dos pedidos se baseando no evento bill_created da Vindi.
 

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -48,11 +48,17 @@ class Vindi_API
     /**
      * @param array $data
      *
-     * @return string
+     * @return mixed
      */
     private function build_body($data)
     {
-        return json_encode($data);
+        $body = null;
+
+        if (!empty($data)) {
+            $body = json_encode($data);
+        }
+
+        return $body;
     }
 
     /**
@@ -61,7 +67,7 @@ class Vindi_API
      */
     private function get_auth_header()
     {
-        return sprintf('Basic %s:', base64_encode($this->key));
+        return sprintf('Basic %s', base64_encode($this->key . ":"));
     }
 
     /**

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -340,7 +340,7 @@ class Vindi_API
                 }
             }
 
-            set_transient('vindi_payment_methods', $payment_methods, 12 * HOUR_IN_SECONDS);
+            set_transient('vindi_payment_methods', $payment_methods, 1 * HOUR_IN_SECONDS);
         }
 
         $this->accept_bank_slip = $payment_methods['bank_slip'];

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -52,7 +52,7 @@ class Vindi_Dependencies
     */
     public static function missing_notice($name, $link)
     {
-        echo '<div class="error"><p>' . sprintf(__('WooCommerce Vindi Gateway depende da última versão do %s para funcionar!', VINDI_IDENTIFIER), "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
+        echo '<div class="error"><p>' . sprintf(__('WooCommerce Vindi Subscriptions depende da última versão do %s para funcionar!', VINDI_IDENTIFIER), "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.0
 Tested up to: 4.4
-Stable Tag: 1.2.0
+Stable Tag: 1.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -61,6 +61,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 1.2.1 - 10/10/2016 =
+- Ajustes no problema de comunicação com a API da Vindi.
+
 = 1.2.0 - 05/10/2016 =
 - Alterada a forma de renovação dos pedidos se baseando no evento bill_created da Vindi.
 

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,7 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 == Changelog ==
 = 1.2.1 - 10/10/2016 =
 - Ajustes no problema de comunicação com a API da Vindi.
+- Alterando o cache métodos de pagamento para 1 hora.
 
 = 1.2.0 - 05/10/2016 =
 - Alterada a forma de renovação dos pedidos se baseando no evento bill_created da Vindi.

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 1.2.0
+* Version: 1.2.1
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.0
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '1.2.0';
+		const VERSION = '1.2.1';
 
         /**
 		 * @var string


### PR DESCRIPTION
Esse PR ajusta dois bugs. Um primeiro deles é um problema no header Authorization e o outro era um problema de envio de payload em verbos HTTP que não suportam. Também aproveitei para alterar o tempo de vida do transient de métodos de pagamento para apenas 1 hora, 12 era muito tempo.
