### PR TITLE
Correção de comportamentos de periodicidade no Woocommerce [DEV-399]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 1.2.2 - 24/01/2017
+# 1.2.2 - 20/02/2017
 - Ajuste na mensagem de envio de boleto bancário.
-- Adicionado os arquivos .PO e .MO para facilitar traduções.
+- Ajustes na exibição de periodicidade para assinaturas com cobranças diferentes de mensais.
 
 # 1.2.1 - 10/10/2016
 - Ajustes no problema de comunicação com a API da Vindi.

--- a/assets/js/simple-subscription-fields.js
+++ b/assets/js/simple-subscription-fields.js
@@ -12,7 +12,7 @@
         
         $(".wc_input_subscription_period_interval").val(plan.interval_count);
         $(".wc_input_subscription_period").val(plan.interval.toString().replace(/s/g, ''));
-        $(".wc_input_subscription_length").val(plan.billing_cycles);
+        $(".wc_input_subscription_length").val(plan.billing_cycles || 0);
       });
     });
   }(jQuery)

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -34,7 +34,7 @@ class Vindi_API
     /**
      * @var string API base path.
      */
-    const BASE_PATH = 'https://app.vindi.com.br/api/v1/';
+    const BASE_PATH = 'https://staging-recurrent.vindi.com.br/api/v1/';
 
     /**
      * @param string $key

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -34,7 +34,7 @@ class Vindi_API
     /**
      * @var string API base path.
      */
-    const BASE_PATH = 'https://staging-recurrent.vindi.com.br/api/v1/';
+    const BASE_PATH = 'https://app.vindi.com.br/api/v1/';
 
     /**
      * @param string $key

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -116,9 +116,11 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 
             add_filter('woocommerce_subscription_period_interval_strings',
                 function ($intervals) {
-                    return array_merge($intervals, [
-                        7, 8, 9, 10, 11, 12, 13
-                    ]);
+                    foreach ([7, 8, 9, 10, 11, 12, 13] as $new_interval) {
+                        array_push($intervals, $new_interval);
+                    }
+
+                    return $intervals;
                 }
             );
 


### PR DESCRIPTION
Hoje, a periodicidade do Woocommerce entende que assinaturas mensais com dia de cobrança específico são bimestrais. Esta PR corrige este comportamento.