### PR TITLE
Bug/adiciona quantidade em item de fatura avulsa [INT-1]

### DIFF
--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -414,10 +414,16 @@ class Vindi_Payment
     {
         $product_items  = [];
 
-        for($i=0 ; $i < $order_item['qty'] ; $i++) {
-            $product_items[] = array(
-                'product_id' => $order_item['vindi_id'],
-                'amount'     => $order_item['price'],
+        if(empty($order_item)){
+            return $product_items;
+        } else {
+        $product_items[] = array(
+            'product_id'        => $order_item['vindi_id'],
+            'quantity'          => $order_item['qty'],
+            'pricing_schema'    => [
+                'price'            => $order_item['price'],
+                'schema_type'       => 'per_unit'
+            ]
             );
         }
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -414,20 +414,19 @@ class Vindi_Payment
     {
         $product_items  = [];
 
-        if(empty($order_item)){
+        if(!empty($order_item)){
+            $product_items[] = array(
+                'product_id'        => $order_item['vindi_id'],
+                'quantity'          => $order_item['qty'],
+                'pricing_schema'    => [
+                    'price'            => $order_item['price'],
+                    'schema_type'       => 'per_unit'
+                ]
+            );
             return $product_items;
         } else {
-        $product_items[] = array(
-            'product_id'        => $order_item['vindi_id'],
-            'quantity'          => $order_item['qty'],
-            'pricing_schema'    => [
-                'price'            => $order_item['price'],
-                'schema_type'       => 'per_unit'
-            ]
-            );
+            return $product_items;
         }
-
-        return $product_items;
     }
 
     protected function build_product_items_for_subscription($order_item)

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -346,8 +346,11 @@ class Vindi_Payment
             $order_items[] = $this->build_discount_item_for_bill();
         }
 
+
         foreach ($order_items as $order_item) {
-            $product_items = array_merge($product_items, $this->$call_build_items($order_item));
+            if($item = $this->$call_build_items($order_item)) {
+                $product_items[] = $item;
+            }
         }
 
         if (empty($product_items)) {
@@ -412,27 +415,24 @@ class Vindi_Payment
 
     protected function build_product_items_for_bill($order_item)
     {
-        $product_items  = [];
-
-        if(!empty($order_item)){
-            $product_items[] = array(
-                'product_id'        => $order_item['vindi_id'],
-                'quantity'          => $order_item['qty'],
-                'pricing_schema'    => [
-                    'price'            => $order_item['price'],
-                    'schema_type'       => 'per_unit'
-                ]
-            );
-            return $product_items;
-        } else {
-            return $product_items;
+        if(empty($order_item)) {
+            return false;
         }
+
+        return [
+            'product_id'        => $order_item['vindi_id'],
+            'quantity'          => $order_item['qty'],
+            'pricing_schema'    => [
+                'price'             => $order_item['price'],
+                'schema_type'       => 'per_unit'
+            ]
+        ];
     }
 
     protected function build_product_items_for_subscription($order_item)
     {
         if(empty($order_item)) {
-            return [];
+            return false;
         }
 
 
@@ -476,7 +476,7 @@ class Vindi_Payment
 
         }
         
-        return [$product_item];
+        return $product_item;
     }
     /**
      * @param $customer_id


### PR DESCRIPTION
Corrige a forma como é enviado um item com quantidade para a Vindi. Até esse momento o WC enviava um 1 para 1. Isso gera um erro quando o cliente vende muitos itens no mesmo pedido. Com esse ajuste a quantidade nos itens é levada em consideração e repassada para a Vindi da mesma forma que está no checkout do WC.
Ex:
Antes:
Venda de 3 garrafas de cerveja era enviada para a Vindi como:
item: Cerveja | Qty: 1
item: Cerveja | Qty: 1
item: Cerveja | Qty: 1

Venda de 3 garrafas de cerveja agora é enviada para a Vindi como:
item: Cerveja
Quantidade: 3.
