### PR TITLE
continuando correções no tratamento de webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.2 - 26/07/2017
+- Correções no tratamento de webhooks.
+
 # 3.0.1 - 20/07/2017
 - Ajustes na renovação de pedidos.
 - Melhoria no registro de itens em compras avulsas.

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -37,7 +37,7 @@ class Vindi_Webhook_Handler
             $this->container->logger->log($e->getMessage());
 
             if(2 === $e->getCode()) {
-                http_response_code(422);
+                header("HTTP/1.0 422 Unprocessable Entity");
                 die($e->getMessage());
             }
         }
@@ -132,15 +132,9 @@ class Vindi_Webhook_Handler
         if(empty($data->bill->subscription)) {
             $order = $this->find_order_by_id($data->bill->code);
         } else {
-            $wc_subscription_id    = $data->bill->subscription->code;
             $vindi_subscription_id = $data->bill->subscription->id;
             $cycle                 = $data->bill->period->cycle;
             
-            if(!$this->subscription_has_order_in_cycle($vindi_subscription_id, $cycle)) {
-                http_response_code(422);
-            }
-            
-            $subscription   = $this->find_subscription_by_id($wc_subscription_id);
             $order          = $this->find_order_by_subscription_and_cycle($vindi_subscription_id, $cycle);
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: erico.pedroso, tales.galvao.vindi, wnarde, lyoncesar
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.4
-Tested up to: 4.7
-Stable Tag: 3.0.0
+Tested up to: 4.8
+Stable Tag: 3.0.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -61,6 +61,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 3.0.2 - 26/07/2017 =
+- Correções no tratamento de webhooks.
+
 = 3.0.1 - 20/07/2017 =
 - Ajustes na renovação de pedidos.
 - Melhoria no registro de itens em compras avulsas.

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 3.0.1
+* Version: 3.0.2
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.0
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '3.0.1';
+		const VERSION = '3.0.2';
 
         /**
 		 * @var string


### PR DESCRIPTION
Foi identificado um bug no plugin, está relacionado ao código de retorno http.
A versão 5.5 do PHP não tem suporte ao código http 422, por isso ao receber um webhook bill_paid ele sempre devolvia o código 200, confirmando o recebimento e processamento do webhook.
Isso gerava um problema de confirmação de pagamento nos pedidos de renovação dentro do WooCommerce. Esse PR seta o código de retorno, forçando assim a resposta esperada nesses casos.
