### PR TITLE
fix verificacao de dependencias

### DIFF
--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -73,7 +73,7 @@ class Vindi_Dependencies
             $plugin_data   = get_plugin_data(ABSPATH . "wp-content/plugins/" . $path);
             $version_match = $plugin['version'];
 
-            if(!in_array($path, self::$active_plugins ) || array_key_exists($path, self::$active_plugins)) {
+            if(!in_array($path, self::$active_plugins ) && !array_key_exists($path, self::$active_plugins)) {
                 add_action('admin_notices', self::missing_notice(key($plugin), $version_match[1], current($plugin)));
                 return false;
             }


### PR DESCRIPTION
Ao colocar o plugin no ar em um Multisite encontramos alguns problemas com a verificação de dependências.

O Woocommerce estava ativo para a rede, enquanto o "checkout fields for brazil" estava ativo apenas no site que utilizaria o plugin da Vindi.

A verificação falhou de várias maneiras.

Olhando o código, creio que a maneira certa de verificar seja essa que proponho.

Ou seja, verificar se o plugin não está na lista dos plugins ativos do site e nem (&&) na lista dos ativos na rede.

Com a regra OU, a verificação sempre falhava...

A segunda regra também estava errada, por que não tinha a exclamação na frente. Então se o plugin estava ativo na rede, ele caía naquela condição.

