### PR TITLE
Altera constante para a pasta do plugin

### DIFF
--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -70,7 +70,7 @@ class Vindi_Dependencies
     public static function plugins_are_activated($plugins)
     {
         foreach($plugins as $path => $plugin) {
-            $plugin_data   = get_plugin_data(ABSPATH . "wp-content/plugins/" . $path);
+            $plugin_data   = get_plugin_data(WP_PLUGIN_DIR . "/" . $path);
             $version_match = $plugin['version'];
 
             if(!in_array($path, self::$active_plugins ) || array_key_exists($path, self::$active_plugins)) {


### PR DESCRIPTION
Instalações utilizando o [bedrock](https://github.com/roots/bedrock) a pasta de plugins fica em outro caminho.

Alterei a constante para funcionar em instalações utilizando ou não o bedrock.