### PR TITLE
Bug/pedido duplicado wc - INT-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 - Adicionado parcelamento de assinaturas (deve ser configurado no painel da Vindi).
 - Adicionado suporte a multilojas.
 - Adicionada integração com o ambiente Sandbox da Vindi.
-- Correção na renovação de pedidos em integrações com o WC Memberships.
+- Ajuste na renovação de pedidos do WC Subscriptions.
+- Adicionado suporte a integração com o WC Memberships.
 
 # 3.0.3 - 14/08/2017
 - Ajustes no desconto de faturas avulsas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.4 - 19/09/2017
+- Adicionado parcelamento de assinaturas (deve ser configurado no painel da Vindi).
+- Adicionado suporte a multilojas.
+- Adicionada integração com o ambiente Sandbox da Vindi.
+- Correção na renovação de pedidos em integrações com o WC Memberships.
+
 # 3.0.3 - 14/08/2017
 - Ajustes no desconto de faturas avulsas.
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -270,6 +270,8 @@ class Vindi_Payment
 
         $this->add_download_url_meta_for_subscription($subscription);
 
+        remove_action( 'woocommerce_scheduled_subscription_payment', 'WC_Subscriptions_Manager::prepare_renewal' );
+
         return $this->finish_payment($subscription['bill']);
     }
 

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -98,7 +98,11 @@ class Vindi_Webhook_Handler
         add_post_meta($order->id, 'vindi_wc_cycle', $renew_infos['cycle']);
         add_post_meta($order->id, 'vindi_wc_bill_id', $renew_infos['bill_id']);
         add_post_meta($order->id, 'vindi_wc_subscription_id', $renew_infos['vindi_subscription_id']);
+
         $this->container->logger->log('Novo Período criado: Pedido #'.$order->id);
+
+        // We've already processed the renewal
+        remove_action( 'woocommerce_scheduled_subscription_payment', 'WC_Subscriptions_Manager::prepare_renewal' );
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,12 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 3.0.4 - 19/09/2017 =
+- Adicionado parcelamento de assinaturas (deve ser configurado no painel da Vindi).
+- Adicionado suporte a multilojas.
+- Adicionada integração com o ambiente Sandbox da Vindi.
+- Correção na renovação de pedidos em integrações com o WC Memberships.
+
 = 3.0.3 - 14/08/2017 =
 - Ajustes no cupom de desconto de faturas avulsas.
 

--- a/readme.txt
+++ b/readme.txt
@@ -65,7 +65,8 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - Adicionado parcelamento de assinaturas (deve ser configurado no painel da Vindi).
 - Adicionado suporte a multilojas.
 - Adicionada integração com o ambiente Sandbox da Vindi.
-- Correção na renovação de pedidos em integrações com o WC Memberships.
+- Ajuste na renovação de pedidos do WC Subscriptions.
+- Adicionado suporte a integração com o WC Memberships.
 
 = 3.0.3 - 14/08/2017 =
 - Ajustes no cupom de desconto de faturas avulsas.

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 3.0.3
+* Version: 3.0.4
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.0
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '3.0.3';
+		const VERSION = '3.0.4';
 
         /**
 		 * @var string


### PR DESCRIPTION
O WooCommerce Subscriptions (WCS) tem um hook que automatiza as renovações de pedidos, ele não interfere no nosso plugin, mas quando a loja usa o WooCommerce Memberships junto com o Subscriptions ele passa a interferir e duplica os pedidos na loja.
Esse PR inativa o hook de renovação do WCS quando a assinatura é gerada e novamente quando um novo pedido é gerado.
