### PR TITLE
Ajuste nas compras avulsas parceladas [INT-51]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.5 - 25/09/2017
+- Ajuste no parcelamento de fatura avulsa.
+
 # 3.0.4 - 19/09/2017
 - Adicionado parcelamento de assinaturas (deve ser configurado no painel da Vindi).
 - Adicionado suporte a multilojas.

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -495,7 +495,7 @@ class Vindi_Payment
      */
     protected function installments()
     {
-        if('credit_card' == $this->payment_method_code())
+        if('credit_card' == $this->payment_method_code() && ! is_null($_POST['vindi_cc_installments']))
             return $_POST['vindi_cc_installments'];
 
         return 1;

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: erico.pedroso, tales.galvao.vindi, wnarde, lyoncesar
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.4
-Tested up to: 4.8.1
-Stable Tag: 3.0.3
+Tested up to: 4.8.2
+Stable Tag: 3.0.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -61,6 +61,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 3.0.5 - 25/09/2017 =
+- Ajuste no parcelamento de fatura avulsa
+
 = 3.0.4 - 19/09/2017 =
 - Adicionado parcelamento de assinaturas (deve ser configurado no painel da Vindi).
 - Adicionado suporte a multilojas.

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,11 +3,11 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 3.0.4
+* Version: 3.0.5
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.0
-* Tested up to: 4.8.1
+* Tested up to: 4.8.2
 *
 * Text Domain: vindi-woocommerce-subscriptions
 * Domain Path: /languages/
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '3.0.4';
+		const VERSION = '3.0.5';
 
         /**
 		 * @var string


### PR DESCRIPTION
As faturas avulsas estão precisando de um ajuste para garantir que a quantidade de parcelas seja preenchida. Esse PR força a quantidade de parcelas em 1x quando ela não foi informada.
