### PR TITLE
[INT-60] Feature/Cancelamento WC-Memberships

### DIFF
--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -63,6 +63,24 @@ class Vindi_Dependencies
     }
 
     /**
+    * @return  boolean
+    */
+    public function memberships_are_activated()
+    {
+        $memberships = [
+            'woocommerce-memberships/woocommerce-memberships.php' => [
+                'WooCommerce Memberships' => 'http://www.woothemes.com/products/woocommerce-memberships/'
+            ]
+        ];
+
+        if(self::plugins_are_activated($memberships)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
     * @param array $plugin
     *
     * @return boolean

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -53,5 +53,4 @@ class Vindi_Subscription_Status_Handler
         $vindi_subscription_id_meta = get_post_meta($wc_subscription->id, 'vindi_wc_subscription_id');
         return end($vindi_subscription_id_meta);
     }
-        }
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -25,7 +25,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_subscription($wc_subscription)
     {
-        $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
+        $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription->id), true);
     }
 
     /**
@@ -40,7 +40,7 @@ class Vindi_Subscription_Status_Handler
             if(false == $memberships) {
                 $wc_subscription->update_status('cancelled');
             } else {
-                $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
+                $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription->id), true);
             }
         }
     }
@@ -48,9 +48,9 @@ class Vindi_Subscription_Status_Handler
     /**
      * @param WC_Subscription $wc_subscription
      **/
-    public function get_vindi_subscription_id($wc_subscription)
+    public function get_vindi_subscription_id($wc_subscription_id)
     {
-        $vindi_subscription_id_meta = get_post_meta($wc_subscription->id, 'vindi_wc_subscription_id');
+        $vindi_subscription_id_meta = get_post_meta($wc_subscription_id, 'vindi_wc_subscription_id');
         return end($vindi_subscription_id_meta);
     }
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -50,7 +50,6 @@ class Vindi_Subscription_Status_Handler
      **/
     public function get_vindi_subscription_id($wc_subscription_id)
     {
-        $vindi_subscription_id_meta = get_post_meta($wc_subscription_id, 'vindi_wc_subscription_id');
-        return end($vindi_subscription_id_meta);
+        return end(get_post_meta($wc_subscription_id, 'vindi_wc_subscription_id'));
     }
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -25,7 +25,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_subscription($wc_subscription)
     {
-        $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription->id), true);
+        $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
     }
 
     /**
@@ -40,7 +40,7 @@ class Vindi_Subscription_Status_Handler
             if(false == $memberships) {
                 $wc_subscription->update_status('cancelled');
             } else {
-                $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription->id), true);
+                $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
             }
         }
     }
@@ -48,8 +48,8 @@ class Vindi_Subscription_Status_Handler
     /**
      * @param WC_Subscription $wc_subscription
      **/
-    public function get_vindi_subscription_id($wc_subscription_id)
+    public function get_vindi_subscription_id($wc_subscription)
     {
-        return end(get_post_meta($wc_subscription_id, 'vindi_wc_subscription_id'));
+        return end(get_post_meta($wc_subscription->id, 'vindi_wc_subscription_id'));
     }
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -25,10 +25,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_subscription($wc_subscription)
     {
-        $vindi_subscription_id_meta = get_post_meta($wc_subscription->id, 'vindi_wc_subscription_id');
-        $vindi_subscription_id      = end($vindi_subscription_id_meta);
-
-        $this->container->api->delete_subscription($vindi_subscription_id, true);
+        $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
     }
 
     /**
@@ -37,7 +34,24 @@ class Vindi_Subscription_Status_Handler
      **/
     public function filter_pre_cancelled_status($wc_subscription, $new_status)
     {
-        if('pending-cancel' === $new_status)
-            $wc_subscription->update_status('cancelled');
+        if('pending-cancel' === $new_status) {
+            $memberships = Vindi_Dependencies::memberships_are_activated();
+
+            if(false == $memberships) {
+                $wc_subscription->update_status('cancelled');
+            } else {
+                $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
+            }
+        }
     }
+
+    /**
+     * @param WC_Subscription $wc_subscription
+     **/
+    public function get_vindi_subscription_id($wc_subscription)
+    {
+        $vindi_subscription_id_meta = get_post_meta($wc_subscription->id, 'vindi_wc_subscription_id');
+        return end($vindi_subscription_id_meta);
+    }
+        }
 }


### PR DESCRIPTION
## Motivação
O WC-Subscriptions possui integração com um plugin chamado WC-Memberships, esse plugin faz um controle de acesso ao portal do nosso cliente baseado no status das assinaturas do WC-Subscriptions.
Os clientes que usam esse tipo de integração não estão conseguindo fazer o cancelamento de uma assinatura sem impactar o acesso do cliente final, isso porque ao solicitar o cancelamento de uma assinatura na área do cliente o nosso plugin faz o cancelamento imediato da assinatura.
Conforme a documentação do WC-Subscriptions, o comportamento ideal seria manter a assinatura com o status 'pending cancelation':
https://docs.woocommerce.com/document/subscriptions/statuses/
![screenshot from 2017-10-18 19-21-29](https://user-images.githubusercontent.com/15332442/31743354-a33bafc2-b439-11e7-85d7-0f8c546f86dc.png)
## Solução
Apenas usando  o status 'pending cancelation' o problema não foi resolvido porque o WC faz o cancelamento da assinatura baseado no horário de criação dela.
_Ex: Uma assinatura mensal gerada ás 16hs do dia 01/10 será cancelada apenas ás 16hs do dia 01/11._
Para evitar a cobrança de uma assinatura já cancelada acredito que a melhor opção seja cancelar a assinatura na Vindi assim que o cliente solicitar. No WCS a assinatura fica pendente de cancelamento garantindo com isso o acesso do cliente até o termino do período pago e evitando a cobrança da assinatura cancelada.

