### PR TITLE
[INT-74] Resolve duplicidade de pedidos com o método next_payment

### DIFF
--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -124,6 +124,7 @@ class Vindi_Webhook_Handler
 
         if(!$this->subscription_has_order_in_cycle($renew_infos['vindi_subscription_id'], $renew_infos['cycle'])) {
             $this->subscription_renew($renew_infos);
+            $this->update_next_payment($data);
         }
     }
 
@@ -338,4 +339,17 @@ class Vindi_Webhook_Handler
 
         return new WP_Query($args);
 	}
+
+    /**
+     * Update next payment schedule of subscription
+     * @param $next_payment string
+     * @param $subscription_id int wc subscription id
+     **/
+    private function update_next_payment($data)
+    {
+        $subscription = $this->find_subscription_by_id($data->bill->subscription->code);
+        $next_payment = date('Y-m-d H:i:s', strtotime($data->bill->period->end_at . ' + 3 days'));
+
+        $subscription->update_dates(array('next_payment' => $next_payment));
+    }
 }


### PR DESCRIPTION
# Motivação
Estão acontecendo duplicidades de pedido no painel do WP.
Investigando os casos eu notei que o WCS tem uma tarefa agendada para gerar a renovação dos pedidos, gerando um pedido pelo próprio WCS e outro pelo nosso plugin.
# Solução
A primeira tentativa foi remover a tarefa agendada, mas isso não funcionou bem.
Outra tentativa foi remover a data de renovação, mas isso gera problemas se o cliente desativar o nosso plugin.
O que entendi como melhor opção foi alterar a data agendada pelo WCS para 3 dias após o encerramento do período renovado.
Escolhi 3 dias porque se acontecer algum problema no ambiente do cliente e os webhooks não chegarem nós ainda tentamos enviar por 2 dias, só adicionei mais um dia por segurança.

Para alterar a data de agendamento eu criei o método 'update_next_payment' e chamo ele após a geração de um pedido de renovação.
