### PR TITLE
[INT-12] Cancelamento de assinaturas com WC Memberships via painel da Vindi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.0.6 - 03/12/2017
+- Correção de duplicidade de pedidos em utilização com o WooCommerce Memberships.
+- Melhorias no cadastro de telefones(dentro da Vindi).
+- Ajuste no cancelamento de assinaturas com WooCommerce Memberships.
+
 # 3.0.5 - 25/09/2017
 - Ajuste no parcelamento de fatura avulsa.
 

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -65,7 +65,7 @@ class Vindi_Dependencies
     /**
     * @return  boolean
     */
-    public function memberships_are_activated()
+    public function wc_memberships_is_activated()
     {
         $memberships = [
             'woocommerce-memberships/woocommerce-memberships.php' => [

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -35,9 +35,9 @@ class Vindi_Subscription_Status_Handler
     public function filter_pre_cancelled_status($wc_subscription, $new_status)
     {
         if('pending-cancel' === $new_status) {
-            $memberships = Vindi_Dependencies::memberships_are_activated();
+            $wc_memberships = Vindi_Dependencies::wc_memberships_is_activated();
 
-            if(false == $memberships) {
+            if($wc_memberships == false) {
                 $wc_subscription->update_status('cancelled');
             } else {
                 $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -202,7 +202,14 @@ class Vindi_Webhook_Handler
     {
         $subscription_id = $data->subscription->code;
         $subscription    = $this->find_subscription_by_id($subscription_id);
-        $subscription->cancel_order();
+
+        $memberships = Vindi_Dependencies::memberships_are_activated();
+
+        if(false == $memberships){
+            $subscription->update_status('cancelled');
+        } else{
+            $subscription->update_status('pending-cancel');
+        }
     }
 
     /**

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -203,9 +203,9 @@ class Vindi_Webhook_Handler
         $subscription_id = $data->subscription->code;
         $subscription    = $this->find_subscription_by_id($subscription_id);
 
-        $memberships = Vindi_Dependencies::memberships_are_activated();
+        $wc_memberships = Vindi_Dependencies::wc_memberships_is_activated();
 
-        if(false == $memberships){
+        if($wc_memberships == false){
             $subscription->update_status('cancelled');
         } else{
             $subscription->update_status('pending-cancel');

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -205,7 +205,7 @@ class Vindi_Webhook_Handler
 
         $wc_memberships = Vindi_Dependencies::wc_memberships_is_activated();
 
-        if($wc_memberships == false){
+        if($wc_memberships == false || $subscription->has_status('on-hold')){
             $subscription->update_status('cancelled');
         } else{
             $subscription->update_status('pending-cancel');

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,11 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 3.0.6 - 03/12/2017 =
+- Correção de duplicidade de pedidos em utilização com o WooCommerce Memberships.
+- Ajustes no cadastro de telefones.
+- Ajuste no cancelamento de assinaturas com WooCommerce Memberships.
+
 = 3.0.5 - 25/09/2017 =
 - Ajuste no parcelamento de fatura avulsa
 

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,11 +3,11 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 3.0.5
+* Version: 3.0.6
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.0
-* Tested up to: 4.8.2
+* Tested up to: 4.9
 *
 * Text Domain: vindi-woocommerce-subscriptions
 * Domain Path: /languages/
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '3.0.5';
+		const VERSION = '3.0.6';
 
         /**
 		 * @var string


### PR DESCRIPTION
# Motivação
Quando o WC Memberships está ativado as assinaturas precisam cumprir a duração total que foram contratadas, mas o nosso plugin ainda não tem o comportamento ideal. Ele faz o cancelamento imediato da assinatura e com isso o cliente final perde o acesso ao conteúdo contratado antes da data de encerramento da assinatura dele.
# Solução
Já fizemos uma correção no PR [#49](https://github.com/vindi/vindi-woocommerce-subscriptions/pull/49). Mas o comportamento antigo continua acontecendo quando uma assinatura é cancelada dentro do painel da Vindi.
Nesse PR eu adicionei uma condicional que verifica se o WC Memberships está ativo na loja e muda o status para 'pending-cancel' ou 'cancelled', caso não tenha o plugin ativo. Isso resolve o problema.
