### PR TITLE
Correção para valor do produto por quantidade

### DIFF
--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -396,7 +396,7 @@ class Vindi_Payment
             $product                       = $this->get_product($order_item);
             $order_items[$key]['type']     = 'product';
             $order_items[$key]['vindi_id'] = $product->vindi_id;
-            $order_items[$key]['price']    = $order_item['total'];
+            $order_items[$key]['price']    = (float) $product->get_price();
         }
 
         return $order_items;


### PR DESCRIPTION
A alteração realizada no pull #52 possibilita que o valor do produto seja manipulado através de outras integrações e plugins, tornando-o compatível com alguns plugins de alterações de produtos.

O valor do item é enviado para a Vindi como o valor total do mesmo produto em um pedido; Porém, se a quantidade do produto for maior que 1, o preço total é multiplicado pela quantidade.

Ex:
WooCommerce -> (2 unidades) produto teste (R$ 50,00 cada) -> (Total R$ 100,00)  
Vindi -> (2 unidades) produto teste (R$ 100,00 cada) -> (Total R$ 200,00)

Comportamento relatado também na Issue #60 

Essa alteração, visa normalizar o comportamento desse método, porém limita a alteração do valor do produto por plugins terceiros.