### PR TITLE
Incluída classe css na imagem de CC no checkout

### DIFF
--- a/templates/creditcard-checkout.html.php
+++ b/templates/creditcard-checkout.html.php
@@ -19,7 +19,7 @@
                 </label>
                 <br>
                 <?php echo $user_payment_profile['holder_name']; ?><br>
-                <div style="background: url('https://s3.amazonaws.com/recurrent/payment_companies/<?php echo $user_payment_profile['payment_company']?>.png') no-repeat center right; background-size: auto 90%;">
+                <div class="vindi-old-paymentcompany" style="background: url('https://s3.amazonaws.com/recurrent/payment_companies/<?php echo $user_payment_profile['payment_company']?>.png') no-repeat center right; background-size: auto 90%;">
                     <?php echo $user_payment_profile['card_number']; ?>
                 </div>
                 <input class="vindi-old-cc-data-check" type="hidden" value='1' name="vindi-old-cc-data-check">


### PR DESCRIPTION
Incluí a classe vindi-old-paymentcompany na imagem da bandeira do cartão de crédito quando já existe um cartão cadastrado no perfil do cliente. Necessário para manipular o css dessa div e ajustar aos temas customizados.