### PR TITLE
[INT-79] Feature/Remove dependência do woocommerce subscriptions

### DIFF
--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -35,10 +35,10 @@ class Vindi_Dependencies
                 'WooCommerce' => 'https://wordpress.org/extend/plugins/woocommerce/',
                 'version'     => ['>=', '3.0']
             ],
-            'woocommerce-subscriptions/woocommerce-subscriptions.php' => [
-                'WooCommerce Subscriptions' => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
-                'version'     => ['>=', '2.2']
-            ],
+            // 'woocommerce-subscriptions/woocommerce-subscriptions.php' => [
+            //     'WooCommerce Subscriptions' => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
+            //     'version'     => ['>=', '2.2']
+            // ],
             'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php' => [
                 'WooCommerce Extra Checkout Fields for Brazil' => 'https://wordpress.org/extend/plugins/woocommerce-extra-checkout-fields-for-brazil/',
                 'version'     => ['>=', '3.5']

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -145,7 +145,7 @@ class Vindi_Dependencies
     /**
     * @return  boolean
     */
-    public function memberships_are_activated()
+    public function wc_memberships_are_activated()
     {
         $wc_memberships = [
             'path'      => 'woocommerce-memberships/woocommerce-memberships.php',

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -44,7 +44,7 @@ class Vindi_Dependencies
                 'plugin'    => [
                     'name'      => 'WooCommerce Extra Checkout Fields for Brazil',
                     'url'       => 'https://wordpress.org/extend/plugins/woocommerce-extra-checkout-fields-for-brazil/',
-                    'version'   => ['>=', '3.7']
+                    'version'   => ['>=', '3.5']
                 ]
             ]
         ];
@@ -129,7 +129,7 @@ class Vindi_Dependencies
             'plugin'    => [
                'name'       => 'WooCommerce Subscriptions',
                'url'        => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
-               'version'    => ['>=', '2.2.14']
+               'version'    => ['>=', '2.2']
             ],
         ];
 

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -31,22 +31,35 @@ class Vindi_Dependencies
             self::init();
 
         $required_plugins = [
-            'woocommerce/woocommerce.php' => [
-                'WooCommerce' => 'https://wordpress.org/extend/plugins/woocommerce/',
-                'version'     => ['>=', '3.0']
+            [
+                'path'      => 'woocommerce/woocommerce.php',
+                'plugin'    => [
+                    'name'      => 'WooCommerce',
+                    'url'       => 'https://wordpress.org/extend/plugins/woocommerce/',
+                    'version'   => ['>=', '3.0']
+                ]
             ],
-            // 'woocommerce-subscriptions/woocommerce-subscriptions.php' => [
-            //     'WooCommerce Subscriptions' => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
-            //     'version'     => ['>=', '2.2']
-            // ],
-            'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php' => [
-                'WooCommerce Extra Checkout Fields for Brazil' => 'https://wordpress.org/extend/plugins/woocommerce-extra-checkout-fields-for-brazil/',
-                'version'     => ['>=', '3.5']
+            [
+                'path'      => 'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php',
+                'plugin'    => [
+                    'name'      => 'WooCommerce Extra Checkout Fields for Brazil',
+                    'url'       => 'https://wordpress.org/extend/plugins/woocommerce-extra-checkout-fields-for-brazil/',
+                    'version'   => ['>=', '3.7']
+                ]
             ]
         ];
 
-        if (! self::plugins_are_activated($required_plugins))
-            return false;
+        self::wc_subscriptions_are_activated();
+
+        foreach($required_plugins as $plugin) {
+
+            if(self::plugin_are_active($plugin) == false)
+                return false;
+
+            if(self::verify_version_of_plugin($plugin) == false)
+                return false;
+
+        }
 
         return true;
     }
@@ -63,49 +76,89 @@ class Vindi_Dependencies
     }
 
     /**
+    * @param array plugin
+    *
+    * @return boolean
+    **/
+    public static function plugin_are_active($plugin)
+    {
+        if(in_array($plugin['path'], self::$active_plugins))
+            return true;
+
+        return  false;
+    }
+
+    /**
+    * @param array plugins
+    *
+    * @return boolean
+    **/
+    public static function verify_version_of_plugin($plugin)
+    {
+        $plugin_data = get_plugin_data(ABSPATH . "wp-content/plugins/" . $plugin['path']);
+        $version_match = $plugin['plugin']['version'];
+
+        $version_compare = version_compare(
+                $plugin_data['Version'],
+                $version_match[1],
+                $version_match[0]
+            );
+
+        if($version_compare == false){
+            add_action(
+                'admin_notices',
+                self::missing_notice($plugin['plugin']['name'],
+                    $version_match[1],
+                    $plugin['plugin']['url'])
+            );
+
+            return false;
+        }
+
+        return true;
+
+    }
+
+    /**
+    * @return boolean
+    **/
+    public static function wc_subscriptions_are_activated()
+    {
+        $wc_subscriptions = [
+            'path'      => 'woocommerce-subscriptions/woocommerce-subscriptions.php',
+            'plugin'    => [
+               'name'       => 'WooCommerce Subscriptions',
+               'url'        => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
+               'version'    => ['>=', '2.2.14']
+            ],
+        ];
+
+        if(self::plugin_are_active($wc_subscriptions)){
+            if(self::verify_version_of_plugin($wc_subscriptions))
+                return true;
+        }
+
+        return false;
+
+    }
+
+    /**
     * @return  boolean
     */
     public function memberships_are_activated()
     {
-        $memberships = [
-            'woocommerce-memberships/woocommerce-memberships.php' => [
-                'WooCommerce Memberships' => 'http://www.woothemes.com/products/woocommerce-memberships/'
+        $wc_memberships = [
+            'path'      => 'woocommerce-memberships/woocommerce-memberships.php',
+            'plugin'    => [
+                'name'  => 'WooCommerce Memberships',
+                'url'   => 'http://www.woothemes.com/products/woocommerce-memberships/'
             ]
         ];
 
-        if(self::plugins_are_activated($memberships)) {
+        if(self::plugin_are_active($wc_memberships)) {
             return true;
         }
 
         return false;
-    }
-
-    /**
-    * @param array $plugin
-    *
-    * @return boolean
-    **/
-    public static function plugins_are_activated($plugins)
-    {
-        foreach($plugins as $path => $plugin) {
-            $plugin_data   = get_plugin_data(ABSPATH . "wp-content/plugins/" . $path);
-            $version_match = $plugin['version'];
-
-            if(!in_array($path, self::$active_plugins ) && !array_key_exists($path, self::$active_plugins)) {
-                add_action('admin_notices', self::missing_notice(key($plugin), $version_match[1], current($plugin)));
-                return false;
-            }
-
-            if(empty($plugin['version'])) {
-              return true;
-            }
-
-            if(!version_compare( $plugin_data['Version'], $version_match[1], $version_match[0] )) {
-                add_action('admin_notices', self::missing_notice(key($plugin), $version_match[1], current($plugin)));
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -35,9 +35,9 @@ class Vindi_Subscription_Status_Handler
     public function filter_pre_cancelled_status($wc_subscription, $new_status)
     {
         if('pending-cancel' === $new_status) {
-            $memberships = Vindi_Dependencies::memberships_are_activated();
+            $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
 
-            if(false == $memberships) {
+            if(false == $wc_memberships) {
                 $wc_subscription->update_status('cancelled');
             } else {
                 $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);


### PR DESCRIPTION
# Motivação
Temos recebido pedidos dos nossos clientes para removermos a dependência do WooCommerce Subscriptions (WCS). Isso porque muitos só fazem vendas avulsas.
# Solução
Fiz a remoção de dependência do WCS e testei o comportamento do plugin apenas usando o WooCommerce e Extra checkout fieldz for Brazil. O plugin funcionou normalmente.
Aproveitei para refatorar os métodos responsáveis por fazer a validação de dependências do plugin, isso vai ajudar em casos futuros.