### PR TITLE
[INT-79] Feature/Remove dependência do WCS

### DIFF
--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -79,7 +79,7 @@ class Vindi_Dependencies
     */
     public static function missing_notice($name, $version, $link)
     {
-        echo '<div class="error"><p>' . sprintf(__('WooCommerce Vindi Subscriptions depende da versão %s do %s para funcionar!', VINDI_IDENTIFIER), $version, "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
+        echo '<div class="error"><p>' . sprintf(__('Vindi WooCommerce Subscriptions depende da versão %s do %s para funcionar!', VINDI_IDENTIFIER), $version, "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
     }
 
     /**

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -29,28 +29,33 @@ class Vindi_Dependencies
     {
         if (! self::$active_plugins)
             self::init();
-
         $required_plugins = [
-            'woocommerce/woocommerce.php' => [
-                'WooCommerce' => 'https://wordpress.org/extend/plugins/woocommerce/',
-                'version'     => ['>=', '3.0']
+            [
+                'path'      => 'woocommerce/woocommerce.php',
+                'plugin'    => [
+                    'name'      => 'WooCommerce',
+                    'url'       => 'https://wordpress.org/extend/plugins/woocommerce/',
+                    'version'   => ['>=', '3.0']
+                ]
             ],
-            'woocommerce-subscriptions/woocommerce-subscriptions.php' => [
-                'WooCommerce Subscriptions' => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
-                'version'     => ['>=', '2.2']
-            ],
-            'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php' => [
-                'WooCommerce Extra Checkout Fields for Brazil' => 'https://wordpress.org/extend/plugins/woocommerce-extra-checkout-fields-for-brazil/',
-                'version'     => ['>=', '3.5']
+            [
+                'path'      => 'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php',
+                'plugin'    => [
+                    'name'      => 'WooCommerce Extra Checkout Fields for Brazil',
+                    'url'       => 'https://wordpress.org/extend/plugins/woocommerce-extra-checkout-fields-for-brazil/',
+                    'version'   => ['>=', '3.5']
+                ]
             ]
         ];
-
-        if (! self::plugins_are_activated($required_plugins))
-            return false;
-
+        self::wc_subscriptions_are_activated();
+        foreach($required_plugins as $plugin) {
+            if(self::plugin_are_active($plugin) == false)
+                return false;
+            if(self::verify_version_of_plugin($plugin) == false)
+                return false;
+        }
         return true;
     }
-
     /**
     * @param string $name
     * @param string $link
@@ -61,51 +66,76 @@ class Vindi_Dependencies
     {
         echo '<div class="error"><p>' . sprintf(__('WooCommerce Vindi Subscriptions depende da versão %s do %s para funcionar!', VINDI_IDENTIFIER), $version, "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
     }
-
     /**
-    * @return  boolean
-    */
-    public function wc_memberships_is_activated()
-    {
-        $memberships = [
-            'woocommerce-memberships/woocommerce-memberships.php' => [
-                'WooCommerce Memberships' => 'http://www.woothemes.com/products/woocommerce-memberships/'
-            ]
-        ];
-
-        if(self::plugins_are_activated($memberships)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-    * @param array $plugin
+    * @param array plugin
     *
     * @return boolean
     **/
-    public static function plugins_are_activated($plugins)
+    public static function plugin_are_active($plugin)
     {
-        foreach($plugins as $path => $plugin) {
-            $plugin_data   = get_plugin_data(ABSPATH . "wp-content/plugins/" . $path);
-            $version_match = $plugin['version'];
-
-            if(!in_array($path, self::$active_plugins ) && !array_key_exists($path, self::$active_plugins)) {
-                add_action('admin_notices', self::missing_notice(key($plugin), $version_match[1], current($plugin)));
-                return false;
-            }
-
-            if(empty($plugin['version'])) {
-              return true;
-            }
-
-            if(!version_compare( $plugin_data['Version'], $version_match[1], $version_match[0] )) {
-                add_action('admin_notices', self::missing_notice(key($plugin), $version_match[1], current($plugin)));
-                return false;
-            }
+        if(in_array($plugin['path'], self::$active_plugins))
+            return true;
+        return  false;
+    }
+    /**
+    * @param array plugins
+    *
+    * @return boolean
+    **/
+    public static function verify_version_of_plugin($plugin)
+    {
+        $plugin_data = get_plugin_data(ABSPATH . "wp-content/plugins/" . $plugin['path']);
+        $version_match = $plugin['plugin']['version'];
+        $version_compare = version_compare(
+                $plugin_data['Version'],
+                $version_match[1],
+                $version_match[0]
+            );
+        if($version_compare == false){
+            add_action(
+                'admin_notices',
+                self::missing_notice($plugin['plugin']['name'],
+                    $version_match[1],
+                    $plugin['plugin']['url'])
+            );
+            return false;
         }
-
         return true;
+    }
+    /**
+    * @return boolean
+    **/
+    public static function wc_subscriptions_are_activated()
+    {
+        $wc_subscriptions = [
+            'path'      => 'woocommerce-subscriptions/woocommerce-subscriptions.php',
+            'plugin'    => [
+               'name'       => 'WooCommerce Subscriptions',
+               'url'        => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
+               'version'    => ['>=', '2.2']
+            ],
+        ];
+        if(self::plugin_are_active($wc_subscriptions)){
+            if(self::verify_version_of_plugin($wc_subscriptions))
+                return true;
+        }
+        return false;
+    }
+    /**
+    * @return  boolean
+    */
+    public function wc_memberships_are_activated()
+    {
+        $wc_memberships = [
+            'path'      => 'woocommerce-memberships/woocommerce-memberships.php',
+            'plugin'    => [
+                'name'  => 'WooCommerce Memberships',
+                'url'   => 'http://www.woothemes.com/products/woocommerce-memberships/'
+            ]
+        ];
+        if(self::plugin_are_active($wc_memberships)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -35,7 +35,10 @@ class Vindi_Dependencies
                 'plugin'    => [
                     'name'      => 'WooCommerce',
                     'url'       => 'https://wordpress.org/extend/plugins/woocommerce/',
-                    'version'   => ['>=', '3.0']
+                    'version'   => [
+                        'validation'    => '>=',
+                        'number'        => '3.0'
+                    ]
                 ]
             ],
             [
@@ -43,7 +46,10 @@ class Vindi_Dependencies
                 'plugin'    => [
                     'name'      => 'WooCommerce Extra Checkout Fields for Brazil',
                     'url'       => 'https://wordpress.org/extend/plugins/woocommerce-extra-checkout-fields-for-brazil/',
-                    'version'   => ['>=', '3.5']
+                    'version'   => [
+                        'validation'    => '>=',
+                        'number'        => '3.5'
+                    ]
                 ]
             ]
         ];
@@ -88,9 +94,10 @@ class Vindi_Dependencies
         $version_match = $plugin['plugin']['version'];
         $version_compare = version_compare(
                 $plugin_data['Version'],
-                $version_match[1],
-                $version_match[0]
+                $version_match['number'],
+                $version_match['validation']
             );
+
         if($version_compare == false){
             add_action(
                 'admin_notices',
@@ -98,8 +105,10 @@ class Vindi_Dependencies
                     $version_match[1],
                     $plugin['plugin']['url'])
             );
+
             return false;
         }
+
         return true;
     }
     /**
@@ -112,7 +121,10 @@ class Vindi_Dependencies
             'plugin'    => [
                'name'       => 'WooCommerce Subscriptions',
                'url'        => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
-               'version'    => ['>=', '2.2']
+               'version'    => [
+                    'validation'    => '>=',
+                    'number'        => '2.2'
+                ]
             ],
         ];
         if(self::plugin_are_active($wc_subscriptions)){

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -53,15 +53,24 @@ class Vindi_Dependencies
                 ]
             ]
         ];
+
         self::wc_subscriptions_are_activated();
+
         foreach($required_plugins as $plugin) {
-            if(self::plugin_are_active($plugin) == false)
+            if(self::plugin_are_active($plugin) == false) {
+                self::missing_notice($plugin['plugin']['name'],
+                    $plugin['plugin']['version']['number'],
+                    $plugin['plugin']['url']);
                 return false;
+            }
+
             if(self::verify_version_of_plugin($plugin) == false)
                 return false;
         }
+
         return true;
     }
+
     /**
     * @param string $name
     * @param string $link
@@ -72,6 +81,7 @@ class Vindi_Dependencies
     {
         echo '<div class="error"><p>' . sprintf(__('WooCommerce Vindi Subscriptions depende da versão %s do %s para funcionar!', VINDI_IDENTIFIER), $version, "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
     }
+
     /**
     * @param array plugin
     *
@@ -81,8 +91,10 @@ class Vindi_Dependencies
     {
         if(in_array($plugin['path'], self::$active_plugins))
             return true;
+
         return  false;
     }
+
     /**
     * @param array plugins
     *
@@ -102,7 +114,7 @@ class Vindi_Dependencies
             add_action(
                 'admin_notices',
                 self::missing_notice($plugin['plugin']['name'],
-                    $version_match[1],
+                    $version_match['number'],
                     $plugin['plugin']['url'])
             );
 
@@ -111,6 +123,7 @@ class Vindi_Dependencies
 
         return true;
     }
+
     /**
     * @return boolean
     **/
@@ -127,12 +140,16 @@ class Vindi_Dependencies
                 ]
             ],
         ];
+
         if(self::plugin_are_active($wc_subscriptions)){
-            if(self::verify_version_of_plugin($wc_subscriptions))
+            if(self::verify_version_of_plugin($wc_subscriptions)){
                 return true;
+            }
         }
+
         return false;
     }
+
     /**
     * @return  boolean
     */

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -35,9 +35,8 @@ class Vindi_Subscription_Status_Handler
     public function filter_pre_cancelled_status($wc_subscription, $new_status)
     {
         if('pending-cancel' === $new_status) {
-            $wc_memberships = Vindi_Dependencies::wc_memberships_is_activated();
-
-            if($wc_memberships == false) {
+            $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
+            if(false == $wc_memberships) {
                 $wc_subscription->update_status('cancelled');
             } else {
                 $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -203,7 +203,7 @@ class Vindi_Webhook_Handler
         $subscription_id = $data->subscription->code;
         $subscription    = $this->find_subscription_by_id($subscription_id);
 
-        $wc_memberships = Vindi_Dependencies::wc_memberships_is_activated();
+        $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
 
         if($wc_memberships == false || $subscription->has_status('on-hold')){
             $subscription->update_status('cancelled');


### PR DESCRIPTION
# Motivação
Temos recebido pedidos dos nossos clientes para removermos a dependência do WooCommerce Subscriptions (WCS). Isso porque muitos só fazem vendas avulsas.

# Solução
Fiz a remoção de dependência do WCS e testei o comportamento do plugin apenas usando o WooCommerce e Extra checkout fieldz for Brazil. O plugin funcionou normalmente.
Aproveitei para refatorar os métodos responsáveis por fazer a validação de dependências do plugin, isso vai ajudar em casos futuros.