### PR TITLE
Feature/adiciona opcao para quantidade de items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.0 - 22/12/2017
+- Removida a dependência do WooCommerce Subscriptions, com isso o plugin passa a trabalhar com assinaturas (usando o WooCommerce Subscriptions) e também com faturas avulsas (usando apenas o WooCommerce)
+
 # 3.0.7 - 06/12/2017
 - Ajuste no valor de produto por quantidade
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -439,7 +439,7 @@ class Vindi_Payment
                 $subscription_order_item    = $this->order_item(
                     $order_item,
                     $product,
-                    $total_subscription
+                    $total_subscription_item
                 );
                 continue;
             }

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -134,7 +134,16 @@ class Vindi_Settings extends WC_Settings_API
 					'on-hold'      => 'Aguardando',
 					'completed'    => 'Concluído',
 				),
-			),
+      ),
+      'item_quantity'     => array(
+        'title'       => __('Envio de items personalidado', VINDI_IDENTIFIER),
+        'label'       => __('Enviar para a Vindi apenas um item por pedido', VINDI_IDENTIFIER),
+        'type'        => 'checkbox',
+        'description' => __('Envia apenas um item por pedido para a Vindi com o valor total da compra.
+                            Consulte a equipe de suporte antes de habilitar essa opção.',
+                            VINDI_IDENTIFIER),
+        'default'     => 'no',
+      ),
 			'testing'              => array(
 				'title'            => __('Testes', 'vindi-woocommerce'),
 				'type'             => 'title',
@@ -217,6 +226,14 @@ class Vindi_Settings extends WC_Settings_API
         }
 
         return null;
+    }
+
+    /**
+     * @return string 'yes' or 'no'
+     **/
+    public function custom_items_are_active()
+    {
+      return $this->settings['item_quantity'];
     }
 
     /**

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -134,16 +134,16 @@ class Vindi_Settings extends WC_Settings_API
 					'on-hold'      => 'Aguardando',
 					'completed'    => 'Concluído',
 				),
-      ),
-      'item_quantity'     => array(
-        'title'       => __('Envio de items personalidado', VINDI_IDENTIFIER),
-        'label'       => __('Enviar para a Vindi apenas um item por pedido', VINDI_IDENTIFIER),
-        'type'        => 'checkbox',
-        'description' => __('Envia apenas um item por pedido para a Vindi com o valor total da compra.
-                            Consulte a equipe de suporte antes de habilitar essa opção.',
-                            VINDI_IDENTIFIER),
-        'default'     => 'no',
-      ),
+            ),
+            'item_quantity'     => array(
+                'title'       => __('Envio de items personalidado', VINDI_IDENTIFIER),
+                'label'       => __('Enviar para a Vindi apenas um item por pedido. *(Somente para faturas avulsas)', VINDI_IDENTIFIER),
+                'type'        => 'checkbox',
+                'description' => __('Envia apenas um item por pedido para a Vindi com o valor total da compra.
+                                    Consulte a equipe de suporte antes de habilitar esta opção.',
+                                    VINDI_IDENTIFIER),
+                'default'     => 'no',
+            ),
 			'testing'              => array(
 				'title'            => __('Testes', 'vindi-woocommerce'),
 				'type'             => 'title',

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -137,7 +137,7 @@ class Vindi_Settings extends WC_Settings_API
             ),
             'item_quantity'     => array(
                 'title'       => __('Envio de items personalidado', VINDI_IDENTIFIER),
-                'label'       => __('Enviar para a Vindi apenas um item por pedido. *(Somente para faturas avulsas)', VINDI_IDENTIFIER),
+                'label'       => __('Enviar para a Vindi apenas um item por pedido.', VINDI_IDENTIFIER),
                 'type'        => 'checkbox',
                 'description' => __('Envia apenas um item por pedido para a Vindi com o valor total da compra.
                                     Consulte a equipe de suporte antes de habilitar esta opção.',

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: erico.pedroso, tales.galvao.vindi, wnarde, lyoncesar
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.4
-Tested up to: 4.9.1
-Stable Tag: 3.0.7
+Tested up to: 4.9.2
+Stable Tag: 4.0.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -61,6 +61,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 4.0.0 - 22/12/2017 =
+- Removida a dependência do WooCommerce Subscriptions, com isso o plugin passa a trabalhar com assinaturas (usando o WooCommerce Subscriptions) e também com faturas avulsas (usando apenas o WooCommerce)
+
 = 3.0.7 - 06/12/2017 =
 - Ajuste no valor de produto por quantidade
 

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,11 +3,11 @@
 * Plugin Name: Vindi Woocommerce Subscriptions
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
-* Version: 3.0.7
+* Version: 4.0.0
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.4
-* Tested up to: 4.9.1
+* Tested up to: 4.9.2
 *
 * Text Domain: vindi-woocommerce-subscriptions
 * Domain Path: /languages/
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '3.0.7';
+		const VERSION = '4.0.0';
 
         /**
 		 * @var string


### PR DESCRIPTION
# Motivação
Recebemos via ticket uma sugestão de melhoria no plugin.
Empresas que vendem mais de 25 produtos no mesmo pedido não estão conseguindo concluir os pedidos porque existe uma limitação de 25 itens por fatura dentro da Vindi.
# Solução proposta
Criei uma opção na sessão de configurações do plugin:
![screenshot from 2018-01-22 12-09-05](https://user-images.githubusercontent.com/15332442/35224808-6609704c-ff6d-11e7-99f1-2aaccc63a162.png)
Ativando essa opção o plugin fará o envio de apenas um item na fatura da Vindi com o valor total dos produtos comprados no WC.
O pedido no WC não é alterado, apenas o envio de itens para a Vindi.
Seguem alguns exemplos da funcionalidade:
Sem a funcionalidade:
![screenshot from 2018-01-22 12-30-22](https://user-images.githubusercontent.com/15332442/35225707-2d9c258a-ff70-11e7-97dc-009430cef68a.png)
![screenshot from 2018-01-22 12-28-26](https://user-images.githubusercontent.com/15332442/35225713-31322bfe-ff70-11e7-9210-d2c761cc47a7.png)
Com a funcionalidade:
![screenshot from 2018-01-22 12-25-04](https://user-images.githubusercontent.com/15332442/35226344-20ac3a2a-ff72-11e7-9d87-35b2a44288c8.png)
![screenshot from 2018-01-22 12-44-55](https://user-images.githubusercontent.com/15332442/35226349-2616de84-ff72-11e7-8a4d-824085fb6bb2.png)
