### PR TITLE
Remoção de limitação de compras (Brasil)

### DIFF
--- a/includes/class-vindi-bank-slip-gateway.php
+++ b/includes/class-vindi-bank-slip-gateway.php
@@ -35,7 +35,6 @@ class Vindi_BankSlip_Gateway extends Vindi_Base_Gateway
             return false;
 
         return 'yes' === $this->enabled
-            && 'BR' === $this->get_country_code()
             && $this->container->api->accept_bank_slip()
             && $this->container->check_ssl();
     }
@@ -49,11 +48,6 @@ class Vindi_BankSlip_Gateway extends Vindi_Base_Gateway
 
         if (empty($user_country)) {
             _e('Selecione o País para visualizar as formas de pagamento.', VINDI_IDENTIFIER);
-            return;
-        }
-
-        if ($user_country != 'BR') {
-            _e('Vindi não está disponível no seu País.', VINDI_IDENTIFIER);
             return;
         }
 

--- a/includes/class-vindi-creditcard-gateway.php
+++ b/includes/class-vindi-creditcard-gateway.php
@@ -97,7 +97,6 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
         $cc_methods = $methods['credit_card'];
 
         return 'yes' === $this->enabled
-            && 'BR' === $this->get_country_code()
             && count($cc_methods)
             && $this->container->check_ssl();
     }
@@ -141,11 +140,6 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
 
         if (empty($user_country)) {
             _e( 'Selecione o País para visualizar as formas de pagamento.', VINDI_IDENTIFIER);
-            return;
-        }
-
-        if ($user_country != 'BR') {
-            _e('Vindi não está disponível no seu País.', VINDI_IDENTIFIER);
             return;
         }
 


### PR DESCRIPTION
Atualmente, temos alguns clientes com a necessidade de disponibilizar ao cliente 'brasileiro' a compra, com o mesmo residindo em outro país; No plugin da Vindi, existe uma limitação que bloqueia para que os métodos apenas sejam visíveis caso o país selecionado seja o Brasil.

Realizei a exclusão dessas limitações, para que as opções de pagamento sejam exibidas ao cliente, e no caso da falha no pagamento, o retorno será o mesmo de quando uma compra é rejeitada.
