### PR TITLE
Ajusta no tamanho do campo CVC no checkout

### DIFF
--- a/templates/creditcard-checkout.html.php
+++ b/templates/creditcard-checkout.html.php
@@ -86,7 +86,7 @@
                 <span class="required">*</span>
             </label>
 
-            <input type="text" class="input-text wc-credit-card-form-card-cvc" name="vindi_cc_cvc" placeholder="CCV" autocomplete="off" maxlength="4" style="width: 3em;"/>
+            <input type="text" class="input-text wc-credit-card-form-card-cvc" name="vindi_cc_cvc" placeholder="CCV" autocomplete="off" maxlength="4" style="width: 4em;"/>
 
             <span class="help vindi_card_csc_description">
                 <?php _e('3 ou 4 dígitos localizados do verso do cartão.', VINDI_IDENTIFIER); ?>


### PR DESCRIPTION
## Motivação
Em vários checkouts que utilizam um tema personalizado, o campo CVC aparece encolhido onde as vezes não é possível visualizar o conteúdo, ou um número fica oculto.
## Solução proposta
Ajuste no tamanho (width) do campo CVC, para se adequar ao padrão atual de CVVs para algumas bandeiras (4 dígitos); 
Realizamos uma série de testes em temas diversos, e tivemos sucesso ajustando o tamanho do campo.