### PR TITLE
Remove menções ao termo 'Subscriptions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ A [Vindi](http://www.vindi.com.br/) é líder em cobrança recorrente no Brasil.
 1. Ative o plugin.
 
 # Configuração
-1. Ative os Webhooks abaixo na Vindi em Configurações -> Dados da empresa -> API & Webhooks:
+1. Ative os Webhooks abaixo na Vindi em Configurações -> Dados da empresa -> Webhooks:
+    - Assinatura cancelada
     - Assinatura efetuada
     - Cobrança rejeitada
     - Fatura emitida

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![alt text align:center](https://www.vindi.com.br/image/vindi-logo-transparente.png "Vindi")
 
-# Vindi - WooCommerce Subscriptions
+# Vindi - WooCommerce
 
 [![Última Versão no WordPress][ico-version]][link-version]
 [![Licença do Software][ico-license]](license.txt)
@@ -8,7 +8,7 @@
 [![Downloads no Total][ico-downloads]][link-downloads]
 
 ## Descrição
-O **Vindi WooCommerce Subscriptions** oferece uma solução completa para pagamentos únicos e assinaturas com cartão de crédito e boleto utilizando o [Woocommerce Subscriptions](https://www.woothemes.com/products/woocommerce-subscriptions/). Basta ter [uma conta habilitada na Vindi](https://app.vindi.com.br/prospects/new), para começar a cobrar seus clientes.
+O **Vindi WooCommerce** oferece uma solução completa para pagamentos únicos e assinaturas com cartão de crédito e boleto utilizando o [Woocommerce Subscriptions](https://www.woothemes.com/products/woocommerce-subscriptions/). Basta ter [uma conta habilitada na Vindi](https://app.vindi.com.br/prospects/new), para começar a cobrar seus clientes.
 
 # Observações
 - Ainda não são suportados Upgrades ou Downgrades de assinaturas.
@@ -34,9 +34,9 @@ A [Vindi](http://www.vindi.com.br/) é líder em cobrança recorrente no Brasil.
     - Cobrança rejeitada
     - Fatura emitida
     - Fatura paga
-1. Copie a Chave API que está localizada na Vindi em Configurações->Dados da empresa->API & Webhooks.
+1. Copie a Chave API que está localizada na Vindi em Configurações -> Chaves de acesso API.
 1. De volta no WooCommerce Cole a Chave API na página administrativa do plugin WooCommerce -> Configurações -> Vindi:
-1. Após salvar a Chave API o Woocommerce Subscriptions vai preencher o campo com sua URL de retorno + um token de segurança, copie essa URL e cole na Vindi em Configurações -> Dados da empresa -> API & Webhooks -> URL
+1. Após salvar a Chave API o Woocommerce Subscriptions vai preencher o campo com sua URL de retorno + um token de segurança, copie essa URL e cole na Vindi em Configurações -> Webhooks -> URL
 1. De volta no WooCommerce -> Configurações -> Finalizar Compra -> Cartão de crédito / Boleto Bancário.
 1. Em WooCommerce -> Campos do Checkout, ative Tipo de Pessoa Física e Jurídica, RG e Inscrição estadual.
 1. Em WooCommerce -> Configurações -> Assinaturas, marque as opções "Aceitar pagamento manual" e "Desabilitar renovação automatica"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A [Vindi](http://www.vindi.com.br/) é líder em cobrança recorrente no Brasil.
 1. Ative o plugin.
 
 # Configuração
-1. Ative os Webhooks abaixo na Vindi em Configurações -> Dados da empresa -> Webhooks:
+1. Ative os Webhooks abaixo na Vindi em Configurações -> Webhooks:
     - Assinatura cancelada
     - Assinatura efetuada
     - Cobrança rejeitada

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -156,7 +156,7 @@ class Vindi_API
             'headers' => array(
                 'Authorization' => $this->get_auth_header(),
                 'Content-Type'  => 'application/json',
-                'User-Agent'    => sprintf('Vindi-WooCommerce-Subscriptions/%s; %s', Vindi_WooCommerce_Subscriptions::VERSION, get_bloginfo( 'url' )),
+                'User-Agent'    => sprintf('Vindi-WooCommerce/%s; %s', Vindi_WooCommerce_Subscriptions::VERSION, get_bloginfo( 'url' )),
             ),
             'method'    => $method,
             'timeout'   => 60,
@@ -727,7 +727,7 @@ class Vindi_API
 			'headers' => [
 				'Authorization' => 'Basic ' . base64_encode($api_key . ':'),
 				'Content-Type'  => 'application/json',
-			    'User-Agent'    => sprintf('Vindi-WooCommerce-Subscriptions/%s; %s', Vindi_WooCommerce_Subscriptions::VERSION, get_bloginfo( 'url' )),
+			    'User-Agent'    => sprintf('Vindi-WooCommerce/%s; %s', Vindi_WooCommerce_Subscriptions::VERSION, get_bloginfo( 'url' )),
 			],
 			'method'    => $method,
 			'timeout'   => 60,

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -79,7 +79,7 @@ class Vindi_Dependencies
     */
     public static function missing_notice($name, $version, $link)
     {
-        echo '<div class="error"><p>' . sprintf(__('Vindi WooCommerce Subscriptions depende da versão %s do %s para funcionar!', VINDI_IDENTIFIER), $version, "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
+        echo '<div class="error"><p>' . sprintf(__('O  Plugin Vindi WooCommerce depende da versão %s do %s para funcionar!', VINDI_IDENTIFIER), $version, "<a href=\"{$link}\">" . __($name, VINDI_IDENTIFIER) . '</a>') . '</p></div>';
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -34,7 +34,8 @@ A [Vindi](http://www.vindi.com.br/) é líder em cobrança recorrente no Brasil.
 1. Ative o plugin.
 
 = Configuração =
-1. Ative os Webhooks abaixo na Vindi em Configurações -> Dados da empresa -> API & Webhooks:
+1. Ative os Webhooks abaixo na Vindi em Configurações -> Dados da empresa -> Webhooks:
+    - Assinatura cancelada
     - Assinatura efetuada
     - Cobrança rejeitada
     - Fatura emitida

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Vindi WooCommerce Subscriptions ===
+=== Vindi WooCommerce ===
 Contributors: erico.pedroso, tales.galvao.vindi, wnarde, lyoncesar
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
@@ -8,15 +8,13 @@ Stable Tag: 4.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
-Venda de assinaturas de produtos e serviços pelo plugin de cobrança recorrente para o WooCommerce Subscriptions.
+Venda de assinaturas de produtos e serviços pelo plugin de cobrança recorrente para o WooCommerce.
 
 == Description ==
-O **Vindi WooCommerce Subscriptions** oferece uma solução completa para pagamentos únicos e assinaturas com cartão de crédito e boleto utilizando o [Woocommerce Subscriptions](https://www.woothemes.com/products/woocommerce-subscriptions/). Basta ter [uma conta habilitada na Vindi](https://app.vindi.com.br/prospects/new), para começar a cobrar seus clientes.
+O **Vindi WooCommerce** oferece uma solução completa para pagamentos únicos e assinaturas com cartão de crédito e boleto utilizando o [Woocommerce Subscriptions](https://www.woothemes.com/products/woocommerce-subscriptions/). Basta ter [uma conta habilitada na Vindi](https://app.vindi.com.br/prospects/new), para começar a cobrar seus clientes.
 
 **Observações**
 - Ainda não são suportados Upgrades ou Downgrades de assinaturas.
-
-Veja também o nosso plugin [Vindi WooCommerce](https://wordpress.org/plugins/vindi-assinaturas-e-cobranca-recorrente/) que oferece uma gestão mais simples e leia [nosso artigo](http://atendimento.vindi.com.br/hc/pt-br/articles/217612217) com um comparativo de recursos entre os dois plugins.
 
 A [Vindi](http://www.vindi.com.br/) é líder em cobrança recorrente no Brasil. Com centenas de clientes usando soluções como pagamento online, soluções de notas fiscais integradas, emissão de boletos por email e PDF, integrações com ERPs e diversos relatórios, a Vindi possibilita um sistema online completo para negócios de venda recorrente. Além disso, empresas podem usar o gateway de pagamento integrado ao billing recorrente ou para faturas avulsas.
 
@@ -41,9 +39,9 @@ A [Vindi](http://www.vindi.com.br/) é líder em cobrança recorrente no Brasil.
     - Cobrança rejeitada
     - Fatura emitida
     - Fatura paga
-1. Copie a Chave API que está localizada na Vindi em Configurações->Dados da empresa->API & Webhooks.
+1. Copie a Chave API que está localizada na Vindi em Configurações -> Chaves de acesso API.
 1. De volta no WooCommerce Cole a Chave API na página administrativa do plugin WooCommerce -> Configurações -> Vindi:
-1. Após salvar a Chave API o Woocommerce Subscriptions vai preencher o campo com sua URL de retorno + um token de segurança, copie essa URL e cole na Vindi em Configurações -> Dados da empresa -> API & Webhooks -> URL
+1. Após salvar a Chave API o Woocommerce Subscriptions vai preencher o campo com sua URL de retorno + um token de segurança, copie essa URL e cole na Vindi em Configurações -> Webhooks -> URL
 1. De volta no WooCommerce -> Configurações -> Finalizar Compra -> Cartão de crédito / Boleto Bancário.
 1. Em WooCommerce -> Campos do Checkout, ative Tipo de Pessoa Física e Jurídica, RG e Inscrição estadual.
 1. Em WooCOmmerce -> Configurações -> Assinaturas, marque as opções "Aceitar pagamento manual" e "Desabilitar renovação automatica"
@@ -55,7 +53,7 @@ Para mais detalhes sobre a instalação de plugins no WordPress leia o tutorial 
 
 Para suporte ou dúvidas relacionadas ao Plugin você pode seguir pelos canais:
 - [Github](https://github.com/vindi/vindi-woocommerce/issues)
-- [Fórum do Plugin](https://wordpress.org/plugins/vindi-woocommerce-assinaturas) (apenas em inglês)
+- [Fórum do Plugin](https://wordpress.org/plugins/vindi-woocommerce-subscriptions/) (apenas em inglês)
 
 Caso necessite de informações sobre a plataforma ou API por favor siga através do canal
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
@@ -177,8 +175,8 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 
 == License ==
 
-Vindi WooCommerce Subscriptions is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+Vindi WooCommerce is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
-Vindi WooCommerce Subscriptions is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+Vindi WooCommerce is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with Vindi WooCommerce Subscriptions. If not, see http://www.gnu.org/licenses/.
+You should have received a copy of the GNU General Public License along with Vindi WooCommerce. If not, see http://www.gnu.org/licenses/.

--- a/readme.txt
+++ b/readme.txt
@@ -34,7 +34,7 @@ A [Vindi](http://www.vindi.com.br/) é líder em cobrança recorrente no Brasil.
 1. Ative o plugin.
 
 = Configuração =
-1. Ative os Webhooks abaixo na Vindi em Configurações -> Dados da empresa -> Webhooks:
+1. Ative os Webhooks abaixo na Vindi em Configurações -> Webhooks:
     - Assinatura cancelada
     - Assinatura efetuada
     - Cobrança rejeitada

--- a/templates/admin-gateway-settings.html.php
+++ b/templates/admin-gateway-settings.html.php
@@ -3,14 +3,14 @@
 <?php if (! $gateway->container->check_ssl()): ?>
     <div class="error">
         <p>
-            <strong><?php _e('Vindi WooCommerce Assinaturas Desativado', VINDI_IDENTIFIER); ?></strong>:
+            <strong><?php _e('Vindi WooCommerce Desabilitado', VINDI_IDENTIFIER); ?></strong>:
             <?php printf(__('Um certificado SSL é necessário para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor e ative a opção %s.', VINDI_IDENTIFIER), '<a href="' . esc_url(admin_url('admin.php?page=wc-settings&tab=checkout&section')) . '">' . __('Forçar finalização segura', VINDI_IDENTIFIER) . '</a>'); ?>
         </p>
     </div>
 <?php endif; ?>
 
 <h3><?php _e('Vindi', VINDI_IDENTIFIER); ?></h3>
-<p><?php _e('Utiliza a rede Vindi como meio de pagamento recorrente para cobranças.', VINDI_IDENTIFIER); ?></p>
+<p><?php _e('Utiliza a rede Vindi como meio de pagamento para cobranças.', VINDI_IDENTIFIER); ?></p>
 <table class="form-table">
     <?php $gateway->generate_settings_html(); ?>
 </table>

--- a/templates/admin-gateway-settings.html.php
+++ b/templates/admin-gateway-settings.html.php
@@ -4,7 +4,7 @@
     <div class="error">
         <p>
             <strong><?php _e('Vindi WooCommerce Desabilitado', VINDI_IDENTIFIER); ?></strong>:
-            <?php printf(__('Um certificado SSL é necessário para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor e ative a opção %s.', VINDI_IDENTIFIER), '<a href="' . esc_url(admin_url('admin.php?page=wc-settings&tab=checkout&section')) . '">' . __('Forçar finalização segura', VINDI_IDENTIFIER) . '</a>'); ?>
+            <?php printf(__('É necessário um <strong> Certificado SSL </strong> para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?>
         </p>
     </div>
 <?php endif; ?>

--- a/templates/admin-settings.html.php
+++ b/templates/admin-settings.html.php
@@ -3,14 +3,14 @@
 <?php if (! $settings->check_ssl()): ?>
 <div class="error">
     <p>
-        <strong><?php _e('Vindi WooCommerce Assinaturas Desativado', VINDI_IDENTIFIER); ?></strong>:
+        <strong><?php _e('Vindi WooCommerce Desabilitado', VINDI_IDENTIFIER); ?></strong>:
         <?php printf(__('Um certificado SSL é necessário para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor e ative a opção %s.', VINDI_IDENTIFIER), '<a href="' . esc_url(admin_url('admin.php?page=wc-settings&tab=checkout&section')) . '">' . __('Forçar finalização segura', VINDI_IDENTIFIER) . '</a>'); ?>
     </p>
 </div>
 <?php endif; ?>
 
 <h3><?php _e('Vindi', VINDI_IDENTIFIER); ?></h3>
-<p><?php _e('Utiliza a rede Vindi como meio de pagamento recorrente para cobranças.', VINDI_IDENTIFIER); ?></p>
+<p><?php _e('Utiliza a rede Vindi como meio de pagamento para cobranças.', VINDI_IDENTIFIER); ?></p>
 <table class="form-table">
     <?php $settings->generate_settings_html(); ?>
 </table>

--- a/templates/admin-settings.html.php
+++ b/templates/admin-settings.html.php
@@ -4,7 +4,7 @@
 <div class="error">
     <p>
         <strong><?php _e('Vindi WooCommerce Desabilitado', VINDI_IDENTIFIER); ?></strong>:
-        <?php printf(__('Um certificado SSL é necessário para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor e ative a opção %s.', VINDI_IDENTIFIER), '<a href="' . esc_url(admin_url('admin.php?page=wc-settings&tab=checkout&section')) . '">' . __('Forçar finalização segura', VINDI_IDENTIFIER) . '</a>'); ?>
+        <?php printf(__('É necessário um <strong> Certificado SSL </strong> para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?>
     </p>
 </div>
 <?php endif; ?>

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
 * Plugin Name: Vindi Woocommerce
 * Plugin URI:
 * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
-* Version: 4.0.1
+* Version: 4.0.2
 * Author: Vindi
 * Author URI: https://www.vindi.com.br
 * Requires at least: 4.4
@@ -37,7 +37,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-		const VERSION = '4.0.1';
+		const VERSION = '4.0.2';
 
         /**
 		 * @var string

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* Plugin Name: Vindi Woocommerce Subscriptions
+* Plugin Name: Vindi Woocommerce
 * Plugin URI:
-* Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce Subscriptions.
+* Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
 * Version: 4.0.1
 * Author: Vindi
 * Author URI: https://www.vindi.com.br


### PR DESCRIPTION
## Motivação
O plugin da Vindi para WooCommerce deixou de ser dependente do **WooCommerce Subscriptions** no PR #65; Desse modo, indagamos a opção de realizar um ajuste nos termos do plugin para remover os termos que incitam a obrigatoriedade do mesmo.
## Solução proposta 
Remoção das menções ao termo '_Subscriptions_', que remete ao plugin de recorrencia do WooCommerce (**WooCommerce Subscriptions**), deixando clara a autonomia do plugin Vindi.