### PR TITLE
Adiciona a compatibilidade com Suspensão e Reativação de assinaturas

### DIFF
--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -209,14 +209,27 @@ class Vindi_API
      *
      * @return array|bool|mixed
      */
-    public function delete_subscription($subscription_id, $cancel_bills = false)
+    public function suspend_subscription($subscription_id, $cancel_bills = false)
     {
         $query = '';
 
-        if($cancel_bills)
-            $query = '?cancel_bills=true';
+        if(!$cancel_bills)
+            $query = '?cancel_bills=false';
 
         if ($response = $this->request('subscriptions/' . $subscription_id . $query, 'DELETE'))
+            return $response;
+
+        return false;
+    }
+
+    /**
+     * @param int   $subscription_id
+     *
+     * @return array|bool|mixed
+     */
+    public function activate_subscription($subscription_id)
+    {
+        if ($response = $this->request('subscriptions/' . $subscription_id . '/reactivate', 'POST'))
             return $response;
 
         return false;

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -135,6 +135,13 @@ class Vindi_Settings extends WC_Settings_API
 					'completed'    => 'Concluído',
 				),
 			),
+            'vindi_synchronism'        => array(
+                'title'            => __('Sincronismo de Status das Assinaturas', VINDI_IDENTIFIER),
+                'type'             => 'checkbox',
+                'label'      => __('Enviar alterações de status nas assinaturas do WooCommerce', VINDI_IDENTIFIER),
+                'description'      => __('Envia as alterações de status nas assinaturas do WooCommerce para Vindi.', VINDI_IDENTIFIER),
+                'default'          => 'no',
+            ),
 			'testing'              => array(
 				'title'            => __('Testes', 'vindi-woocommerce'),
 				'type'             => 'title',
@@ -205,6 +212,15 @@ class Vindi_Settings extends WC_Settings_API
     public function send_nfe_information()
     {
         return 'yes' === $this->settings['send_nfe_information'];
+    }
+
+    /**
+     * Get Vindi Synchronism status
+     * @return string
+     **/
+    public function get_synchronism_status()
+    {
+        return 'yes' === $this->settings['vindi_synchronism'];
     }
 
     /**

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -7,7 +7,7 @@ class Vindi_Subscription_Status_Handler
      **/
     private $container;
 
-    private $vindi_subscription_id
+    private $vindi_subscription_id;
 
     public function __construct(Vindi_Settings $container)
     {

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -12,35 +12,67 @@ class Vindi_Subscription_Status_Handler
         $this->container = $container;
 
         add_action('woocommerce_subscription_status_cancelled',array(
-            &$this, 'cancelled_subscription'
+            &$this, 'cancelled_status'
         ));
 
         add_action('woocommerce_subscription_status_updated',array(
-            &$this, 'filter_pre_cancelled_status'
+            &$this, 'filter_pre_status'
         ), 1, 2);
-    }
-
-    /**
-     * @param WC_Subscription $wc_subscription
-     **/
-    public function cancelled_subscription($wc_subscription)
-    {
-        $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
     }
 
     /**
      * @param WC_Subscription $wc_subscription
      * @param string          $new_status
      **/
-    public function filter_pre_cancelled_status($wc_subscription, $new_status)
+    public function filter_pre_status($wc_subscription, $new_status)
     {
-        if('pending-cancel' === $new_status) {
-            $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
-            if(false == $wc_memberships) {
-                $wc_subscription->update_status('cancelled');
-            } else {
-                $this->container->api->delete_subscription($this->get_vindi_subscription_id($wc_subscription), true);
-            }
+
+        $subscripton_id = $this->get_vindi_subscription_id($wc_subscription);
+
+        switch ($new_status) {
+            case 'on-hold':
+                $this->suspend_status($subscripton_id);
+                break;
+            case 'active':
+                $this->active_status($wc_subscription);
+                break;           
+            default:
+                $this->cancelled_status($wc_subscription,$new_status);
+                break;
+        }
+    }
+
+    /**
+     * @param WC_Subscription $subscripton_id
+     **/
+    public function suspend_status($subscripton_id)
+    {
+        $this->container->api->suspend_subscription($subscripton_id);
+    }
+
+    /**
+     * @param WC_Subscription $wc_subscription
+     * @param string          $new_status
+     **/
+    public function cancelled_status($wc_subscription,$new_status)
+    {
+        $subscripton_id = $this->get_vindi_subscription_id($wc_subscription);
+        $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
+
+        if(false == $wc_memberships && 'pending-cancel' === $new_status) {
+            $wc_subscription->update_status('cancelled');
+        }
+
+        $this->container->api->suspend_subscription($subscripton_id, true); 
+    }
+
+    /**
+     * @param WC_Subscription $wc_subscription
+     **/
+    public function active_status($wc_subscription)
+    {
+        if($wc_subscription->has_status('on-hold')){
+            $this->container->api->activate_subscription($subscripton_id);
         }
     }
 

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -205,10 +205,10 @@ class Vindi_Webhook_Handler
 
         $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
 
-        if($wc_memberships == false || $subscription->has_status('on-hold')){
-            $subscription->update_status('cancelled');
-        } else{
+        if($wc_memberships || $this->container->get_synchronism_status()){
             $subscription->update_status('pending-cancel');
+        } else{
+            $subscription->update_status('cancelled');
         }
     }
 

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -213,6 +213,17 @@ class Vindi_Webhook_Handler
     }
 
     /**
+     * Process subscription_reactivated event from webhook
+     * @param $data array
+     **/
+    private function subscription_reactivated($data)
+    {
+        $subscription_id = $data->subscription->code;
+        $subscription    = $this->find_subscription_by_id($subscription_id);
+        $subscription->update_status('active','Assinatura ' . $subscription_id . ' reativada pela Vindi.');
+    }
+
+    /**
      * find a subscription by id
      * @param int id
      * @return WC_Subscription

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -218,9 +218,11 @@ class Vindi_Webhook_Handler
      **/
     private function subscription_reactivated($data)
     {
-        $subscription_id = $data->subscription->code;
-        $subscription    = $this->find_subscription_by_id($subscription_id);
-        $subscription->update_status('active','Assinatura ' . $subscription_id . ' reativada pela Vindi.');
+        if ($this->container->get_synchronism_status()){
+            $subscription_id = $data->subscription->code;
+            $subscription    = $this->find_subscription_by_id($subscription_id);
+            $subscription->update_status('active','Assinatura ' . $subscription_id . ' reativada pela Vindi.');
+        }
     }
 
     /**

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -106,10 +106,6 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                 &$this, 'action_links'
             ));
 
-            add_filter('wcs_view_subscription_actions', array(
-                &$this, 'user_subscriptions_actions'
-            ), 100, 2);
-
             add_filter('woocommerce_my_account_my_orders_actions', array(
                 &$this, 'user_related_orders_actions'
             ), 100, 2);
@@ -358,23 +354,6 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 
 			return $valid;
 		}
-
-        /**
-         * @param array           $actions
-         * @param WC_Subscription $subscription
-         **/
-        public function user_subscriptions_actions($actions, $subscription)
-        {
-            // remove from second array to allow action
-            $filtred_actions = $this->filter_actions($actions, array(
-                'resubscribe',
-                'suspend',
-                'reactivate',
-                //'cancel',
-            ));
-
-            return $filtred_actions;
-        }
 
         /**
          * @param array    $actions


### PR DESCRIPTION
## Motivação
O plugin da Vindi atualmente não trata as ações de suspensão e reativação das assinaturas; Desse modo, caso o consumidor realize a suspensão no WooCommerce, a ação não será refletida na Vindi.
As opções avançadas (**Suspender** / **Reativar** / "**Assinar novamente**") estavam desativadas por esse motivo.
## Solução proposta
Tornar o plugin compatível com a suspenção/cancelamento e reativação de assinaturas, realizando as requisições para a Vindi e realizando o tratamento dos Webhooks, disponibilizando também ao usuário o opção de _"resubscribe"_.