### PR TITLE
Remoção da verificação da função forcessl do WooCommerce

### DIFF
--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -247,16 +247,7 @@ class Vindi_Settings extends WC_Settings_API
     public function check_ssl()
     {
         return $this->api->is_merchant_status_trial_or_sandbox()
-            || $this->check_woocommerce_force_ssl_checkout();
-    }
-
-    /**
-     * @return boolean
-     **/
-    public function check_woocommerce_force_ssl_checkout()
-    {
-        return 'yes' === get_option('woocommerce_force_ssl_checkout')
-            && is_ssl();
+            || is_ssl();
     }
 
     /**

--- a/templates/admin-gateway-settings.html.php
+++ b/templates/admin-gateway-settings.html.php
@@ -3,8 +3,8 @@
 <?php if (! $gateway->container->check_ssl()): ?>
     <div class="error">
         <p>
-            <strong><?php _e('Vindi WooCommerce Assinaturas Desativado', VINDI_IDENTIFIER); ?></strong>:
-            <?php printf(__('Um certificado SSL é necessário para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor e ative a opção %s.', VINDI_IDENTIFIER), '<a href="' . esc_url(admin_url('admin.php?page=wc-settings&tab=checkout&section')) . '">' . __('Forçar finalização segura', VINDI_IDENTIFIER) . '</a>'); ?>
+            <strong><?php _e('Vindi WooCommerce ', VINDI_IDENTIFIER); ?></strong>:
+            <?php printf(__('requer um certificado SSL para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?>
         </p>
     </div>
 <?php endif; ?>

--- a/templates/admin-gateway-settings.html.php
+++ b/templates/admin-gateway-settings.html.php
@@ -3,8 +3,7 @@
 <?php if (! $gateway->container->check_ssl()): ?>
     <div class="error">
         <p>
-            <strong><?php _e('Vindi WooCommerce ', VINDI_IDENTIFIER); ?></strong>:
-            <?php printf(__('requer um certificado SSL para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?>
+            <?php printf(__('É necessário um <strong> Certificado SSL </strong> para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?> 
         </p>
     </div>
 <?php endif; ?>

--- a/templates/admin-settings.html.php
+++ b/templates/admin-settings.html.php
@@ -3,8 +3,7 @@
 <?php if (! $settings->check_ssl()): ?>
 <div class="error">
     <p>
-            <strong><?php _e('Vindi WooCommerce ', VINDI_IDENTIFIER); ?></strong>:
-            <?php printf(__('requer um certificado SSL para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?>
+            <?php printf(__('É necessário um <strong> Certificado SSL </strong> para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?> 
     </p>
 </div>
 <?php endif; ?>

--- a/templates/admin-settings.html.php
+++ b/templates/admin-settings.html.php
@@ -3,8 +3,8 @@
 <?php if (! $settings->check_ssl()): ?>
 <div class="error">
     <p>
-        <strong><?php _e('Vindi WooCommerce Assinaturas Desativado', VINDI_IDENTIFIER); ?></strong>:
-        <?php printf(__('Um certificado SSL é necessário para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor e ative a opção %s.', VINDI_IDENTIFIER), '<a href="' . esc_url(admin_url('admin.php?page=wc-settings&tab=checkout&section')) . '">' . __('Forçar finalização segura', VINDI_IDENTIFIER) . '</a>'); ?>
+            <strong><?php _e('Vindi WooCommerce ', VINDI_IDENTIFIER); ?></strong>:
+            <?php printf(__('requer um certificado SSL para ativar este método de pagamento em modo de produção. Por favor, verifique se um certificado SSL está instalado em seu servidor !')); ?>
     </p>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
## Motivação 
Com a atualização do WooCommerce, essa função foi alterada, e não é mais exibida no painel administrativo. Essa falha impede o usuário de ativar o plugin da Vindi caso haja algum erro de configuração no certificado.
## Solução proposta
O ajuste realizado realiza a verificação do certificado SSL por página (Configurações e Checkout), realizando as devidas tratativas.
- Exibe a informação que é necessário um certificado válido nas configurações do Plugin;
- Oculta os métodos de pagamento caso a plataforma esteja em produção porém sem o certificado SSL instalado.