### PR TITLE
Enviar todos os valores do carrinho, agora incluindo a taxa

### DIFF
--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -369,6 +369,7 @@ class Vindi_Payment
         $product_items  = [];
         $order_items    = $this->build_product_order_items();
         $order_items[]  = $this->build_shipping_item();
+        $order_items[]  = $this->build_tax_item();
 
         if('bill' === $order_type) {
             $order_items[] = $this->build_discount_item_for_bill();
@@ -419,6 +420,25 @@ class Vindi_Payment
         );
 
         return $shipping_item;
+    }
+
+    protected function build_tax_item()
+    {
+        $taxItem  = [];
+        $taxTotal = $this->order->get_total_tax();
+        if(empty($taxTotal)) {
+            return $taxItem;
+        }
+
+        $item          = $this->container->api->find_or_create_product("Taxa", 'wc-tax');
+        $taxItem = array(
+            'type'     => 'tax',
+            'vindi_id' => $item['id'],
+            'price'    => (float) $taxTotal,
+            'qty'      => 1
+        );
+
+        return $taxItem;
     }
 
     protected function build_discount_item_for_bill()

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -396,7 +396,7 @@ class Vindi_Payment
             $product                       = $this->get_product($order_item);
             $order_items[$key]['type']     = 'product';
             $order_items[$key]['vindi_id'] = $product->vindi_id;
-            $order_items[$key]['price']    = (float) $product->get_price();
+            $order_items[$key]['price']    = (float) $order_items[$key]['subtotal'] / $order_items[$key]['qty'];
         }
 
         return $order_items;

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -344,7 +344,7 @@ class Vindi_Payment
      **/
   private function return_cycle_from_product_type($item)
     {
-        if ($item['type'] == 'shipping')
+        if ($item['type'] == 'shipping' || $item['type'] == 'tax')
             return null;
         
         if(!$this->is_subscription_type($item->get_product())) {

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -426,7 +426,7 @@ class Vindi_Payment
     {
         $taxItem  = [];
         $taxTotal = $this->container->woocommerce->cart->get_total_tax();
-        if(empty($taxTotal)) {
+        if (empty($taxTotal)) {
             return $taxItem;
         }
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -425,7 +425,7 @@ class Vindi_Payment
     protected function build_tax_item()
     {
         $taxItem  = [];
-        $taxTotal = $this->order->get_total_tax();
+        $taxTotal = $this->container->woocommerce->cart->get_total_tax();
         if(empty($taxTotal)) {
             return $taxItem;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.4
 Tested up to: 4.9.5
-Stable Tag: 4.0.1
+Stable Tag: 4.0.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions
 Requires at least: 4.4
 Tested up to: 4.9.5
-Stable Tag: 4.0.2
+Stable Tag: 4.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## Motivação ##
Atualmente o plugin da Vindi envia para a geração de faturas o valor cadastrado no produto, não tratando as alterações realizadas por taxas/descontos ou até mesmo plugins terceiros (extensões) do WooCommerce; A remoção dessa limitação torna o plugin compatível com as principais extensões do WooCommerce, dando mais liberdade de personalização aos clientes.
## Solução proposta ## 
- Alteração do valor enviado para a Vindi (Agora o valor do produto que será enviado é o atual do carrinho)
- Adição do envio da Taxa (Agora as Taxas cadastradas no WooCommerce serão enviadas nas faturas em forma de um produto genérico, utilizando o valor total de todas as taxas no carrinho)
- O ciclo de duração das Taxas em uma assinatura segue o mesmo do frete (Indeterminado)