### PR TITLE
 Adição da Transação de Verificação

### DIFF
--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -316,7 +316,12 @@ class Vindi_API
         $log['card_number'] = '**** *' . substr($log['card_number'], -3);
         $log['card_cvv']    = '***';
 
-        return $this->request('payment_profiles', 'POST', $body, $log);
+        return $this->request('payment_profiles', 'POST', $body, $log)['id'];
+    }
+
+    public function verify_customer_payment_profile($payment_profile_id)
+    {
+        return 'success' === $this->request('payment_profiles/' . $payment_profile_id . '/verify', 'POST', $body, $log)['transaction']['status'];
     }
 
     /**

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -316,7 +316,7 @@ class Vindi_API
         $log['card_number'] = '**** *' . substr($log['card_number'], -3);
         $log['card_cvv']    = '***';
 
-        return $this->request('payment_profiles', 'POST', $body, $log)['id'];
+        return $this->request('payment_profiles', 'POST', $body, $log)['payment_profile']['id'];
     }
 
     public function verify_customer_payment_profile($payment_profile_id)

--- a/includes/class-vindi-base-gateway.php
+++ b/includes/class-vindi-base-gateway.php
@@ -23,6 +23,7 @@ abstract class Vindi_Base_Gateway extends WC_Payment_Gateway
         $this->container = $container;
         $this->title     = $this->get_option('title');
         $this->enabled   = $this->get_option('enabled');
+        $this->verify_method = $this->get_option('verify_method');
 
         if (is_admin()) {
             add_action('woocommerce_update_options_payment_gateways_' . $this->id, array(&$this, 'process_admin_options'));

--- a/includes/class-vindi-base-gateway.php
+++ b/includes/class-vindi-base-gateway.php
@@ -23,7 +23,6 @@ abstract class Vindi_Base_Gateway extends WC_Payment_Gateway
         $this->container = $container;
         $this->title     = $this->get_option('title');
         $this->enabled   = $this->get_option('enabled');
-        $this->verify_method = $this->get_option('verify_method');
 
         if (is_admin()) {
             add_action('woocommerce_update_options_payment_gateways_' . $this->id, array(&$this, 'process_admin_options'));

--- a/includes/class-vindi-creditcard-gateway.php
+++ b/includes/class-vindi-creditcard-gateway.php
@@ -18,6 +18,7 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
 
         $this->smallest_installment = $this->get_option('smallest_installment');
         $this->installments         = $this->get_option('installments');
+        $this->verify_method        = $this->get_option('verify_method');
 
         parent::__construct($container);
 

--- a/includes/class-vindi-creditcard-gateway.php
+++ b/includes/class-vindi-creditcard-gateway.php
@@ -51,6 +51,12 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
                 'description' => __('Título que o cliente verá durante o processo de pagamento.', VINDI_IDENTIFIER),
                 'default'     => __('Cartão de Crédito', VINDI_IDENTIFIER),
             ),
+            'verify_method' => array(
+                'title'       => __('Transação de Verificação', VINDI_IDENTIFIER),
+                'type'        => 'checkbox',
+                'description' => __(' Realiza a transação de verificação em todos os novos pedidos. (Taxas adicionais por verificação poderão ser cobradas).', VINDI_IDENTIFIER),
+                'default'     => 'no',
+            ),
             'single_charge' => array(
                 'title' => __('Vendas Avulsas', VINDI_IDENTIFIER),
                 'type'  => 'title',
@@ -99,6 +105,15 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
         return 'yes' === $this->enabled
             && count($cc_methods)
             && $this->container->check_ssl();
+    }
+
+    /**
+     * Check if this gateway verify method is enabled
+     * @return bool
+    */
+    public function verify_method()
+    {
+        return 'yes' === $this->verify_method;
     }
 
     /**

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -334,7 +334,7 @@ class Vindi_Payment
         if(false === $cc_info)
             return ;
 
-        $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info);
+        $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info)['payment_profile']['id'];
         if (false === $payment_profile_id)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -337,6 +337,20 @@ class Vindi_Payment
         $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info);
         if (false === $payment_profile_id)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
+
+        if ($this->gateway->verify_method())
+            $this->verify_payment_profile($payment_profile_id);
+    }
+
+    /**
+     * @param int $payment_profile_id
+     *
+     * @throws Exception
+     */
+    protected function verify_payment_profile($payment_profile_id)
+    {
+        if (!$this->container->api->verify_customer_payment_profile($payment_profile_id))
+            $this->abort(__('Não foi possível realizar a verificação do seu cartão de crédito!', VINDI_IDENTIFIER), true);
     }
 
     /**

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -334,7 +334,8 @@ class Vindi_Payment
         if(false === $cc_info)
             return ;
 
-        $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info)['payment_profile']['id'];
+        $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info);
+        
         if (false === $payment_profile_id)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
 


### PR DESCRIPTION
## Motivação
Atualmente o plugin da Vindi para WooCommerce não possui a transação de verificação, o que impossibilita os clientes Vindi de instalarem/utilizaram essa funcionalidade.
Essa extensão pode ser indicada como um diferencial para os clientes, aumentando a confiabilitade do negócio dele tanto quanto um ganho de receita para a Vindi.

## Solução proposta
Esse PR adiciona uma opção para habilitar a função de transação de verificação da Vindi no plugin WooCommerce, que impede a compra nas verificações rejeitadas.