### PR TITLE
Adiciona ciclos do cupom na assinatura

### DIFF
--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -541,7 +541,7 @@ class Vindi_Payment
                 return null;
             case '-1':
                 return $get_plan_length (array_values(
-            $this->container->woocommerce->cart->get_coupons())[0]->get_usage_limit());                         
+            $this->container->woocommerce->cart->get_coupons())[0]->get_usage_limit_per_user());                         
             default: 
                 return $get_plan_length ($cycles_to_discount);
         }

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -540,7 +540,7 @@ class Vindi_Payment
         return  array(array(
                 'discount_type' => 'percentage',
                 'percentage'    => ($this->order->get_total_discount() / $this->order->get_subtotal()) * 100,
-                'cycles'        => $discount_cycles
+                'cycles'        => $discount_cycles ?: null;
             ));
     }
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -540,10 +540,10 @@ class Vindi_Payment
             case '0': 
                 return null;
             case '-1':
-                return $get_plan_lenght (array_values(
+                return $get_plan_length (array_values(
             $this->container->woocommerce->cart->get_coupons())[0]->get_usage_limit());                         
             default: 
-                return $get_plan_lenght ($cycles_to_discount);
+                return $get_plan_length ($cycles_to_discount);
         }
     }
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -510,7 +510,7 @@ class Vindi_Payment
             )
         );
         if (!empty($this->order->get_total_discount()) && $order_item['type'] == 'line_item') {
-            return $this->build_discount_item_for_subscription($order_item, $product_item);
+            $product_item['discounts'] = $this->build_discount_item_for_subscription($order_item, $product_item);
         }
         return $product_item;
     }
@@ -537,13 +537,11 @@ class Vindi_Payment
                 break;
         }
 
-        return $product_item['discounts']  = array(
-            array(
+        return  array(array(
                 'discount_type' => 'percentage',
                 'percentage'    => ($this->order->get_total_discount() / $this->order->get_subtotal()) * 100,
                 'cycles'        => $discount_cycles
-            )
-        );
+            ));
     }
 
     /**

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -527,7 +527,6 @@ class Vindi_Payment
             if (!$cycles_to_discount) {
                 return  null;
             }
-            
             $plan_cycles = $this->container->api->get_plan_billing_cycles($this->get_plan());
 
             if ($plan_cycles) { 
@@ -540,8 +539,10 @@ class Vindi_Payment
             case '0': 
                 return null;
             case '-1':
-                return $get_plan_lenght (array_values(
-            $this->container->woocommerce->cart->get_coupons())[0]->get_usage_limit());                         
+                $customCoupon = get_post_meta(array_values(
+                    $this->container->woocommerce->cart->get_coupons())[0]->id,
+                    '_wcs_number_payments', true);
+                return $get_plan_lenght ($customCoupon);      
             default: 
                 return $get_plan_lenght ($cycles_to_discount);
         }

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -515,7 +515,7 @@ class Vindi_Payment
         return $product_item;
     }
 
-    protected function build_discount_item_for_subscription($product_item)
+    protected function build_discount_item_for_subscription()
     {            
         switch ($cycles_to_discount = $this->container->cycles_to_discount()) {
             case '0':

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -515,7 +515,7 @@ class Vindi_Payment
         return $product_item;
     }
 
-    protected function build_discount_item_for_subscription($order_item, $product_item)
+    protected function build_discount_item_for_subscription($product_item)
     {            
         switch ($cycles_to_discount = $this->container->cycles_to_discount()) {
             case '0':

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -521,7 +521,7 @@ class Vindi_Payment
 
     protected function config_discount_cycles ()
     {
-        $get_plan_lenght = 
+        $get_plan_length = 
         function ($cycles_to_discount) 
         {   
             if (!$cycles_to_discount) {

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -542,7 +542,7 @@ class Vindi_Payment
                 $customCoupon = get_post_meta(array_values(
                     $this->container->woocommerce->cart->get_coupons())[0]->id,
                     '_wcs_number_payments', true);
-                return $get_plan_lenght ($customCoupon);      
+                return $get_plan_length ($customCoupon);      
             default: 
                 return $get_plan_length ($cycles_to_discount);
         }

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -117,6 +117,7 @@ class Vindi_Settings extends WC_Settings_API
                 'description' => __('Número de ciclos que os cupons de desconto serão aplicados nas assinaturas.', VINDI_IDENTIFIER),
                 'default'     => '0',
                 'options'     => array(
+                    '-1' => 'Ciclos do cupom',
                     '0'  => 'Todos os ciclos',
                     '1'  => '1 ciclo',
                     '2'  => '2 ciclos',


### PR DESCRIPTION
## Motivação
A configuração de duração de cupons em uma assinatura é **global**; Sendo assim, se definir duração de 1 ciclo, a duração será refletida para todos os cupons.
Alguns clientes desejam utilizar uma duração personalizada por cupons.

## Solução Proposta
A alteração, disponibiliza a opção de utilizar a duração configurada no cupom como duração do desconto na assinatura.