### PR TITLE
Corrige cancelamento de assinaturas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.0.1 - 29/08/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.0.1)
+
+### Corrigido
+- Corrige erro no cancelamento de assinaturas em algumas versões do PHP
+
+
 ## [5.0.0 - 28/08/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.0.0)
 
 ### Adicionado

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -153,7 +153,7 @@ class Vindi_Dependencies
     /**
     * @return  boolean
     */
-    public function wc_memberships_are_activated()
+    public static function wc_memberships_are_activated()
     {
         $wc_memberships = [
             'path'      => 'woocommerce-memberships/woocommerce-memberships.php',

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -7,8 +7,6 @@ class Vindi_Subscription_Status_Handler
      **/
     private $container;
 
-    private $vindi_subscription_id;
-
     public function __construct(Vindi_Settings $container)
     {
         $this->container = $container;
@@ -27,13 +25,10 @@ class Vindi_Subscription_Status_Handler
      * @param string          $new_status
      **/
     public function filter_pre_status($wc_subscription, $new_status)
-    {
-
-        $this->vindi_subscription_id = $this->get_vindi_subscription_id($wc_subscription);
-
+    {   
         switch ($new_status) {
             case 'on-hold':
-                $this->suspend_status();
+                $this->suspend_status($this->get_vindi_subscription_id($wc_subscription));
                 break;
             case 'active':
                 $this->active_status($wc_subscription);
@@ -44,10 +39,10 @@ class Vindi_Subscription_Status_Handler
         }
     }
 
-    public function suspend_status()
+    public function suspend_status($vindi_subscription_id)
     {
         if($this->container->get_synchronism_status()){
-            $this->container->api->suspend_subscription($this->vindi_subscription_id);
+            $this->container->api->suspend_subscription($vindi_subscription_id);
         }
     }
 
@@ -61,7 +56,7 @@ class Vindi_Subscription_Status_Handler
             $wc_subscription->update_status('cancelled');
         }
 
-        $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
+        $this->container->api->suspend_subscription($this->get_vindi_subscription_id($wc_subscription), true); 
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: erico.pedroso, tales.galvao.vindi, wnarde, lyoncesar, laertejr, rt
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions, vindi-woocommerce
 Requires at least: 4.4
-Tested up to: 4.9.6
+Tested up to: 4.9.8
 WC requires at least: 3.0.0
-WC tested up to: 3.4.3
-Stable Tag: 5.0.0
+WC tested up to: 3.4.4
+Stable Tag: 5.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 5.0.1 - 29/08/2018 =
+- Corrige erro no cancelamento de assinaturas em algumas versões do PHP.
+
 = 5.0.0 - 28/08/2018 =
 - Adiciona envio das taxas do WooCommerce.
 - Adiciona envio dos valores atuais do carrinho para os produtos.

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,13 +3,13 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.0.0
+ * Version: 5.0.1
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
- * Tested up to: 4.9.6
+ * Tested up to: 4.9.8
  * WC requires at least: 3.0.0
- * WC tested up to: 3.4.3
+ * WC tested up to: 3.4.4
  *
  * Text Domain: vindi-woocommerce-subscriptions
  * Domain Path: /languages/
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.0.0';
+        const VERSION = '5.0.1';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
Não está sendo possível realizar o cancelamento de assinaturas via painel do cliente (My Account), caso o WooCommerce Memberships não esteja instalado.
A maneira como alguns métodos eram chamados, estava dando conflito em algumas versões do PHP.

## Solução Proposta
- Remover a atribuição de **$this->get_vindi_subscription_id($wc_subscription)** em um método herdado do WooCommerce;
- Tornar estático o método **wc_memberships_are_activated()**