### PR TITLE
Ajusta sincronismo de assinaturas

### DIFF
--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -258,7 +258,7 @@ class Vindi_API
      *
      * @return bool
      */
-    public function get_subscription_status($subscription_id)
+    public function is_subscription_canceled($subscription_id)
     {
         if (isset($this->recentRequest)) {
             unset($this->recentRequest);

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -23,6 +23,11 @@ class Vindi_API
     private $logger;
 
     /**
+     * @var Vindi_Logger
+     */
+    private $recentRequest;
+
+    /**
      * @var String 'Yes' or 'no'
      */
     private $sandbox;
@@ -249,10 +254,27 @@ class Vindi_API
     }
 
     /**
-     * @param string $code
+     * @param string $subscription_id
      *
-     * @return array|bool|mixed
+     * @return bool
      */
+    public function get_subscription_status($subscription_id)
+    {
+        if (isset($this->recentRequest)) {
+            unset($this->recentRequest);
+            return false;
+        }
+
+        $response = $this->request(sprintf('subscriptions/%s', $subscription_id),'GET')['subscription'];
+        
+        if (array_key_exists('status', $response)) {
+            if ($response['status'] != 'canceled') {
+                $this->recentRequest = $subscription_id;
+                return true;
+            }
+        }
+    }
+
     public function find_customer_by_code($code)
     {
         $response = $this->request(sprintf(

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -41,7 +41,7 @@ class Vindi_Subscription_Status_Handler
 
     public function suspend_status($vindi_subscription_id)
     {
-        if($this->container->get_synchronism_status()){
+        if ($this->container->get_synchronism_status()) {
             $this->container->api->suspend_subscription($vindi_subscription_id);
         }
     }
@@ -52,7 +52,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_status($wc_subscription,$new_status)
     {
-        if(!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
+        if (!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
             return $wc_subscription->update_status('cancelled');
         }
         if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {
@@ -65,7 +65,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function active_status($wc_subscription)
     {
-        if($wc_subscription->has_status('on-hold') && $this->container->get_synchronism_status()){
+        if ($wc_subscription->has_status('on-hold') && $this->container->get_synchronism_status()) {
             $this->container->api->activate_subscription($this->vindi_subscription_id);
         }
     }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -55,7 +55,7 @@ class Vindi_Subscription_Status_Handler
         if (!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
             return $wc_subscription->update_status('cancelled');
         }
-        if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {
+        if ($this->container->api->is_subscription_canceled($this->vindi_subscription_id)) {
             $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
         }
     }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -58,10 +58,11 @@ class Vindi_Subscription_Status_Handler
     public function cancelled_status($wc_subscription,$new_status)
     {
         if(false == Vindi_Dependencies::wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
-            $wc_subscription->update_status('cancelled');
+            return $wc_subscription->update_status('cancelled');
         }
-
-        $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
+        if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {
+            $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
+        }
     }
 
     /**

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -52,7 +52,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_status($wc_subscription,$new_status)
     {
-        if(false == Vindi_Dependencies::wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
+        if(!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
             return $wc_subscription->update_status('cancelled');
         }
         if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -200,7 +200,7 @@ class Vindi_Webhook_Handler
      **/
     private function subscription_canceled($data)
     {
-        $subscription    = $this->find_subscription_by_id($data->subscription->code);
+        $subscription = $this->find_subscription_by_id($data->subscription->code);
         
         if ($this->container->get_synchronism_status()
             && ($subscription->has_status('cancelled')

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -200,16 +200,20 @@ class Vindi_Webhook_Handler
      **/
     private function subscription_canceled($data)
     {
-        $subscription_id = $data->subscription->code;
-        $subscription    = $this->find_subscription_by_id($subscription_id);
-
-        $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
-
-        if($wc_memberships || $this->container->get_synchronism_status()){
-            $subscription->update_status('pending-cancel');
-        } else{
-            $subscription->update_status('cancelled');
+        $subscription    = $this->find_subscription_by_id($data->subscription->code);
+        
+        if($this->container->get_synchronism_status()
+            && ($subscription->has_status('cancelled')
+            || $subscription->has_status('pending-cancel')
+            || $subscription->has_status('on-hold'))) {
+            return;
         }
+
+        if (Vindi_Dependencies::wc_memberships_are_activated()) {
+            $subscription->update_status('pending-cancel');
+            return;
+        }
+        $subscription->update_status('cancelled');
     }
 
     /**

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -202,7 +202,7 @@ class Vindi_Webhook_Handler
     {
         $subscription    = $this->find_subscription_by_id($data->subscription->code);
         
-        if($this->container->get_synchronism_status()
+        if ($this->container->get_synchronism_status()
             && ($subscription->has_status('cancelled')
             || $subscription->has_status('pending-cancel')
             || $subscription->has_status('on-hold'))) {

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -209,7 +209,7 @@ class Vindi_Webhook_Handler
             return;
         }
 
-        if (Vindi_Dependencies::wc_memberships_are_activated()) {
+        if ($this->container->dependency->wc_memberships_are_activated()) {
             $subscription->update_status('pending-cancel');
             return;
         }


### PR DESCRIPTION
## Motivação
Estão sendo realizados requests adicionais com o sincronismo de assinaturas habilitado.

## Solução Proposta
Inserir uma validação se já foi realizada alguma requisição do mesmo tipo recentemente.