### PR TITLE
Ajusta comportamento de transação rejeitada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Notas das versões
 
+## [5.2.0 - 11/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
+
+### Ajustado
+- Ajusta sincronismo de assinaturas
+
+### Removido
+- Remove consulta adicional na fatura da Vindi após finalização da compra
+
+
 ## [5.0.1 - 29/08/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.0.1)
 
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Notas das versões
 
-## [5.2.0 - 11/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
+## [5.2.0 - 12/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
 
 ### Ajustado
 - Ajusta sincronismo de assinaturas
+
+### Corrigido
+- Corrige comportamento das transações recusadas
 
 ### Removido
 - Remove consulta adicional na fatura da Vindi após finalização da compra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 ### Corrigido
 - Corrige comportamento das transações recusadas
 
-### Removido
-- Remove consulta adicional na fatura da Vindi após finalização da compra
-
 
 ## [5.0.1 - 29/08/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.0.1)
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -336,7 +336,7 @@ class Vindi_Payment
 
         $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info);
         
-        if (false == $payment_profile_id)
+        if (!$payment_profile_id)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
 
         if ($this->gateway->verify_method())

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -336,7 +336,7 @@ class Vindi_Payment
 
         $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info);
         
-        if (false === $payment_profile_id)
+        if (false == $payment_profile_id)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
 
         if ($this->gateway->verify_method())

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.4
-Stable Tag: 5.0.1
+Stable Tag: 5.2.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,10 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 5.2.0 - 11/09/2018 =
+- Ajusta sincronismo de assinaturas
+- Remove consulta adicional na fatura da Vindi após finalização da compra
+
 = 5.0.1 - 29/08/2018 =
 - Corrige erro no cancelamento de assinaturas em algumas versões do PHP.
 

--- a/readme.txt
+++ b/readme.txt
@@ -65,7 +65,6 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 = 5.2.0 - 12/09/2018 =
 - Ajusta sincronismo de assinaturas
 - Corrige comportamento das transações recusadas
-- Remove consulta adicional na fatura da Vindi após finalização da compra
 
 = 5.0.1 - 29/08/2018 =
 - Corrige erro no cancelamento de assinaturas em algumas versões do PHP.

--- a/readme.txt
+++ b/readme.txt
@@ -62,8 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
-= 5.2.0 - 11/09/2018 =
+= 5.2.0 - 12/09/2018 =
 - Ajusta sincronismo de assinaturas
+- Corrige comportamento das transações recusadas
 - Remove consulta adicional na fatura da Vindi após finalização da compra
 
 = 5.0.1 - 29/08/2018 =

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.0.1
+ * Version: 5.2.0
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.0.1';
+        const VERSION = '5.2.0';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
O consumidor está sendo redirecionado para a página de sucesso de compra, quando o cartão é inválido, sendo exibida a mensagem 'Número de cartão inválido' e sucessivamente 'Sua compra foi aprovada com sucesso'.

## Solução Proposta
Isso se dá, pois quando um cartão inválido é enviado, o retorno da criação é null e não false.
