### PR TITLE
Corrige verificação do status do Memberships

### DIFF
--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -5,7 +5,7 @@ class Vindi_Settings extends WC_Settings_API
     /**
      * @var Vindi_Dependencies
      **/
-    private $dependency;
+    public $dependency;
 
     /**
      * @var Vindi_WooCommerce_Subscriptions


### PR DESCRIPTION
## Motivação
A validação do memberships não está acontecendo pois o atributo responsável está definido como **privado**.

## Solução Proposta
Alterar a declaração do atributo para **publica**.
