### PR TITLE
Ajusta requisições enviadas para a Vindi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Notas das versões
 
+## [5.2.0 - 11/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
+
+### Ajustado
+- Ajusta sincronismo de assinaturas
+
+### Removido
+- Remove consulta adicional na fatura da Vindi após finalização da compra
+
+
 ## [5.0.1 - 29/08/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.0.1)
 
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Notas das versões
 
-## [5.2.0 - 11/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
+## [5.2.0 - 12/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
 
 ### Ajustado
 - Ajusta sincronismo de assinaturas
+
+### Corrigido
+- Corrige comportamento das transações recusadas
 
 ### Removido
 - Remove consulta adicional na fatura da Vindi após finalização da compra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Notas das versões
 
+## [5.3.0 - 01/10/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.3.0)
+
+### Corrigido
+- Ajusta performance do checkout
+
+
+## [5.2.1 - 21/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.1)
+
+### Corrigido
+- Corrige fluxo de assinatura pós-cancelamento no Woocommerce
+
+
 ## [5.2.0 - 12/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
 
 ### Ajustado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 ### Corrigido
 - Corrige comportamento das transações recusadas
 
-### Removido
-- Remove consulta adicional na fatura da Vindi após finalização da compra
-
 
 ## [5.0.1 - 29/08/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.0.1)
 

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -258,7 +258,7 @@ class Vindi_API
      *
      * @return bool
      */
-    public function get_subscription_status($subscription_id)
+    public function is_subscription_canceled($subscription_id)
     {
         if (isset($this->recentRequest)) {
             unset($this->recentRequest);

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -308,7 +308,7 @@ class Vindi_API
     {
         $vindi_customer = $this->find_customer_by_code($wc_customer['code']);
 
-        if (false == $vindi_customer['id']) {
+        if (false == $vindi_customer) {
             return $this->create_customer($wc_customer);
         }
 

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -28,6 +28,11 @@ class Vindi_API
     private $recentRequest;
 
     /**
+     * @var Vindi_Logger
+     */
+    private $vindi_customer;
+
+    /**
      * @var String 'Yes' or 'no'
      */
     private $sandbox;
@@ -277,6 +282,9 @@ class Vindi_API
 
     public function find_customer_by_code($code)
     {
+        if (isset($this->vindi_customer) && $this->vindi_customer['code'] == $code)
+            return $this->vindi_customer;
+
         $response = $this->request(sprintf(
             'customers/search?code=%s',
             $code
@@ -284,7 +292,8 @@ class Vindi_API
 
         if ($response && (1 === count($response['customers'])) &&
             isset($response['customers'][0]['id'])) {
-            return $response['customers'][0];
+            $this->vindi_customer = $response['customers'][0]
+            return $this->vindi_customer;
         }
 
         return false;

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -23,6 +23,11 @@ class Vindi_API
     private $logger;
 
     /**
+     * @var Vindi_Logger
+     */
+    private $recentRequest;
+
+    /**
      * @var String 'Yes' or 'no'
      */
     private $sandbox;
@@ -249,10 +254,27 @@ class Vindi_API
     }
 
     /**
-     * @param string $code
+     * @param string $subscription_id
      *
-     * @return array|bool|mixed
+     * @return bool
      */
+    public function get_subscription_status($subscription_id)
+    {
+        if (isset($this->recentRequest)) {
+            unset($this->recentRequest);
+            return false;
+        }
+
+        $response = $this->request(sprintf('subscriptions/%s', $subscription_id),'GET')['subscription'];
+        
+        if (array_key_exists('status', $response)) {
+            if ($response['status'] != 'canceled') {
+                $this->recentRequest = $subscription_id;
+                return true;
+            }
+        }
+    }
+
     public function find_customer_by_code($code)
     {
         $response = $this->request(sprintf(

--- a/includes/class-vindi-bank-slip-gateway.php
+++ b/includes/class-vindi-bank-slip-gateway.php
@@ -57,7 +57,10 @@ class Vindi_BankSlip_Gateway extends Vindi_Base_Gateway
         }
 
         $is_single_order = $this->is_single_order();
-        $is_trial = $this->container->api->is_merchant_status_trial_or_sandbox();
+
+        if (!($is_trial = $this->container->get_is_active_sandbox()))
+            $is_trial = $this->container->api->is_merchant_status_trial_or_sandbox();
+        
         $this->container->get_template('bankslip-checkout.html.php', compact('is_trial', 'is_single_order'));
     }
 

--- a/includes/class-vindi-creditcard-gateway.php
+++ b/includes/class-vindi-creditcard-gateway.php
@@ -201,16 +201,8 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
         if($this->is_single_order())
             return $this->installments;
         
-        foreach($this->container->woocommerce->cart->cart_contents as $item) {
-            $plan_id[] = $item['data']->get_meta('vindi_subscription_plan');
-        }
-        
-        foreach($plan_id as $id) {
-            $response = $this->container->api->get_plan_installments($id);
-
-            if($response > 1)
-                $installments = $response;               
-        }
+        if(($plan_installments = $this->container->vindi_plan['installments']) > 1)
+            $installments = $plan_installments;               
 
         if(empty($installments))
             return 1;

--- a/includes/class-vindi-creditcard-gateway.php
+++ b/includes/class-vindi-creditcard-gateway.php
@@ -92,7 +92,7 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
     }
 
     /**
-     * Check if this gateway is enabled and available in the user's country
+     * Check if this gateway is enabled and available in the user's checkout
      * @return bool
     */
     public function is_available()
@@ -151,13 +151,6 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
             for ($times = 1; $times <= $max_times; $times++) {
                 $installments[$times] = ceil($total / $times * 100) / 100;
             }
-        }
-
-        $user_country = $this->get_country_code();
-
-        if (empty($user_country)) {
-            _e( 'Selecione o País para visualizar as formas de pagamento.', VINDI_IDENTIFIER);
-            return;
         }
 
         $user_payment_profile = $this->build_user_payment_profile();

--- a/includes/class-vindi-creditcard-gateway.php
+++ b/includes/class-vindi-creditcard-gateway.php
@@ -7,6 +7,10 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
      */
     private $max_installments = 12;
 
+    private $payment_profile;
+
+    private $current_customer;
+
     public function __construct(Vindi_Settings $container)
     {
         $this->id           = 'vindi-wc-creditcard';
@@ -119,15 +123,19 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
     {
         $user_payment_profile = array();
         $user_code            = get_user_meta(wp_get_current_user()->ID, 'vindi_user_code', true);
-        $payment_profile      = $this->container->api->get_payment_profile($user_code);
 
-        if($payment_profile['type'] !== 'PaymentProfile::CreditCard')
+        if (!isset($this->payment_profile) || $this->current_customer != $user_code) {
+            $this->payment_profile = $this->container->api->get_payment_profile($user_code);
+            $this->current_customer = $user_code;
+        }
+
+        if($this->payment_profile['type'] !== 'PaymentProfile::CreditCard')
             return $user_payment_profile;
 
-        if(false === empty($payment_profile)) {
-            $user_payment_profile['holder_name']     = $payment_profile['holder_name'];
-            $user_payment_profile['payment_company'] = $payment_profile['payment_company']['code'];
-            $user_payment_profile['card_number']     = sprintf('**** **** **** %s', $payment_profile['card_number_last_four']);
+        if(false === empty($this->payment_profile)) {
+            $user_payment_profile['holder_name']     = $this->payment_profile['holder_name'];
+            $user_payment_profile['payment_company'] = $this->payment_profile['payment_company']['code'];
+            $user_payment_profile['card_number']     = sprintf('**** **** **** %s', $this->payment_profile['card_number_last_four']);
         }
 
         return $user_payment_profile;
@@ -203,13 +211,14 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
                 break;
         }
         
-        if(($plan_installments = $this->container->api->get_plan($plan_id)['installments']) > 1)
-            $installments = $plan_installments;               
+        $current_plan = $this->container->api->current_plan;
+        if ($current_plan && $current_plan['id'] == $plan_id && !empty($current_plan['installments']))
+            return $current_plan['installments'];
 
-        if(empty($installments))
-            return 1;
+        if(($plan_installments = $this->container->api->get_plan($plan_id)['installments']) > 1)
+            return $plan_installments;               
                 
-        return $installments;
+        return 1;
     }
 
     /**

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -336,7 +336,7 @@ class Vindi_Payment
 
         $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info);
         
-        if (false === $payment_profile_id)
+        if (false == $payment_profile_id)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
 
         if ($this->gateway->verify_method())

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -528,7 +528,7 @@ class Vindi_Payment
             if (!$cycles_to_discount) {
                 return  null;
             }
-            $plan_cycles = $this->container->vindi_plan['billing_cycles'];
+            $plan_cycles = (int) $this->container->api->current_plan['billing_cycles'];
 
             if ($plan_cycles) { 
                 return min($plan_cycles, $cycles_to_discount);
@@ -568,14 +568,14 @@ class Vindi_Payment
      */
     protected function create_subscription($customer_id)
     {
-        $this->container->vindi_plan = $this->container->api->get_plan($this->get_plan());
+        $vindi_plan = $this->get_plan();
         $wc_subscription_array = wcs_get_subscriptions_for_order($this->order->id);
         $wc_subscription       = end($wc_subscription_array);
 
         $body = array(
             'customer_id'         => $customer_id,
             'payment_method_code' => $this->payment_method_code(),
-            'plan_id'             => $this->container->vindi_plan['id'],
+            'plan_id'             => $this->vindi_plan,
             'product_items'       => $this->build_product_items('subscription'),
             'code'                => $wc_subscription->id,
             'installments'        => $this->installments()

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -133,7 +133,7 @@ class Vindi_Payment
             ]
         ));
 
-        $customer = array(
+        $wc_customer = array(
             'name'          => $name,
             'email'         => $email,
             'registry_code' => $cpf_or_cnpj,
@@ -144,22 +144,22 @@ class Vindi_Payment
             'metadata' => $metadata,
         );
 
-        $customer_id = $this->container->api->find_or_create_customer($customer);
+        $vindi_customer = $this->container->api->find_or_create_customer($wc_customer);
 
-        if(!$this->container->api->update_customer_phone($customer_id, $phones)) {
+        if (false == $vindi_customer['id']) {
             $this->abort(__('Falha ao registrar o usuário. Verifique os dados e tente novamente.', VINDI_IDENTIFIER ), true);
         }
 
-        if (false === $customer_id) {
+        if(!$this->container->api->update_customer_phone($vindi_customer['id'], $phones)) {
             $this->abort(__('Falha ao registrar o usuário. Verifique os dados e tente novamente.', VINDI_IDENTIFIER ), true);
         }
 
-        $this->container->logger->log(sprintf('Cliente Vindi: %s', $customer_id));
+        $this->container->logger->log(sprintf('Cliente Vindi: %s', $vindi_customer['id']));
 
         if ($this->is_cc())
-            $this->create_payment_profile($customer_id);
+            $this->create_payment_profile($vindi_customer['id']);
 
-        return $customer_id;
+        return $vindi_customer;
     }
 
     /**
@@ -278,8 +278,8 @@ class Vindi_Payment
      */
     public function process_subscription()
     {
-        $customer_id      = $this->get_customer();
-        $subscription     = $this->create_subscription($customer_id);
+        $customer         = $this->get_customer();
+        $subscription     = $this->create_subscription($customer['id']);
         $wc_subscriptions = wcs_get_subscriptions_for_order($this->order);
         $wc_subscription  = end($wc_subscriptions);
 
@@ -294,7 +294,7 @@ class Vindi_Payment
             $this->abort(__($message, VINDI_IDENTIFIER), true);
         }
 
-        $this->add_download_url_meta_for_subscription($subscription);
+        $this->add_download_url_meta_for_order($subscription, true);
 
         remove_action( 'woocommerce_scheduled_subscription_payment', 'WC_Subscriptions_Manager::prepare_renewal' );
 
@@ -307,8 +307,8 @@ class Vindi_Payment
      */
     public function process_single_payment()
     {
-        $customer_id = $this->get_customer();
-        $bill        = $this->create_bill($customer_id);
+        $customer = $this->get_customer();
+        $bill     = $this->create_bill($customer['id']);
 
         if($message = $this->cancel_if_denied_bill_status($bill)) {
             $this->container->api->delete_bill($bill['id']);
@@ -317,7 +317,7 @@ class Vindi_Payment
         }
 
         add_post_meta($this->order->id, 'vindi_wc_bill_id', $bill['id']);
-        $this->add_download_url_meta_for_single_payment($bill['id']);
+        $this->add_download_url_meta_for_order($bill, false);
 
         return $this->finish_payment($bill);
     }
@@ -334,13 +334,13 @@ class Vindi_Payment
         if(false === $cc_info)
             return ;
 
-        $payment_profile_id = $this->container->api->create_customer_payment_profile($cc_info);
+        $payment_profile = $this->container->api->create_customer_payment_profile($cc_info);
         
-        if (false == $payment_profile_id)
+        if (false == $payment_profile)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
 
         if ($this->gateway->verify_method())
-            $this->verify_payment_profile($payment_profile_id);
+            $this->verify_payment_profile($payment_profile['id']);
     }
 
     /**
@@ -610,9 +610,9 @@ class Vindi_Payment
             'installments'        => $this->installments()
         );
 
-        $bill_id = $this->container->api->create_bill($body);
+        $bill = $this->container->api->create_bill($body);
 
-        if (! $bill_id) {
+        if (! $bill) {
             $this->container->logger->log(sprintf('Erro no pagamento do pedido %s.', $this->order->id));
             $message = sprintf(__('Pagamento Falhou. (%s)', VINDI_IDENTIFIER), $this->container->api->last_error);
             $this->order->update_status('failed', $message);
@@ -620,42 +620,24 @@ class Vindi_Payment
             throw new Exception($message);
         }
 
-        return $bill_id;
+        return $bill;
     }
 
-    /**
-     * @param $subscription
-     */
-    protected function add_download_url_meta_for_subscription($subscription)
+    protected function add_download_url_meta_for_order($sale, $subscription)
     {
-        if (isset($subscription['bill'])) {
-            $bill         = $subscription['bill'];
-            $download_url = false;
-
-            if ('review' === $bill['status']) {
-                $this->container->api->approve_bill($bill['id']);
-                $download_url = $this->container->api->get_bank_slip_download($bill['id']);
-            } elseif (isset($bill['charges']) && count($bill['charges'])) {
-                $download_url = $bill['charges'][0]['print_url'];
+        if ($subscription)
+        {
+            if (isset($sale['bill']) && isset($sale['bill']['charges']) && count($sale['bill']['charges'])) {
+                add_post_meta($this->order->id, 'vindi_wc_invoice_download_url',
+                $sale['bill']['charges'][0]['print_url']);
             }
-
-            if ($download_url)
-                add_post_meta($this->order->id, 'vindi_wc_invoice_download_url', $download_url);
+            return;
         }
-    }
 
-    /**
-     * @param int $bill_id
-     */
-    protected function add_download_url_meta_for_single_payment($bill_id)
-    {
-        $download_url = false;
-
-        if ($this->container->api->approve_bill($bill_id))
-            $download_url = $this->container->api->get_bank_slip_download($bill_id);
-
-        if ($download_url)
-            add_post_meta($this->order->id, 'vindi_wc_invoice_download_url', $download_url);
+        if (isset($sale['charges']) && count($sale['charges'])) {
+            add_post_meta($this->order->id, 'vindi_wc_invoice_download_url',
+            $sale['charges'][0]['print_url']);
+        }
     }
 
     protected function cancel_if_denied_bill_status($bill)

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -528,7 +528,7 @@ class Vindi_Payment
             if (!$cycles_to_discount) {
                 return  null;
             }
-            $plan_cycles = (int) $this->container->api->current_plan['billing_cycles'];
+            $plan_cycles = (int) WC()->session->get('current_plan')['billing_cycles'];
 
             if ($plan_cycles) { 
                 return min($plan_cycles, $cycles_to_discount);
@@ -575,7 +575,7 @@ class Vindi_Payment
         $body = array(
             'customer_id'         => $customer_id,
             'payment_method_code' => $this->payment_method_code(),
-            'plan_id'             => $this->vindi_plan,
+            'plan_id'             => $vindi_plan,
             'product_items'       => $this->build_product_items('subscription'),
             'code'                => $wc_subscription->id,
             'installments'        => $this->installments()
@@ -591,7 +591,8 @@ class Vindi_Payment
 
             throw new Exception($message);
         }
-
+        WC()->session->__unset('current_payment_profile');
+        WC()->session->__unset('current_customer');
         return $subscription;
     }
 
@@ -620,7 +621,8 @@ class Vindi_Payment
 
             throw new Exception($message);
         }
-
+        WC()->session->__unset('current_payment_profile');
+        WC()->session->__unset('current_customer');
         return $bill;
     }
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -528,7 +528,7 @@ class Vindi_Payment
             if (!$cycles_to_discount) {
                 return  null;
             }
-            $plan_cycles = $this->container->api->get_plan_billing_cycles($this->get_plan());
+            $plan_cycles = $this->container->vindi_plan['billing_cycles'];
 
             if ($plan_cycles) { 
                 return min($plan_cycles, $cycles_to_discount);
@@ -568,14 +568,14 @@ class Vindi_Payment
      */
     protected function create_subscription($customer_id)
     {
-        $vindi_plan            = $this->get_plan();
+        $this->container->vindi_plan = $this->container->api->get_plan($this->get_plan());
         $wc_subscription_array = wcs_get_subscriptions_for_order($this->order->id);
         $wc_subscription       = end($wc_subscription_array);
 
         $body = array(
             'customer_id'         => $customer_id,
             'payment_method_code' => $this->payment_method_code(),
-            'plan_id'             => $vindi_plan,
+            'plan_id'             => $this->container->vindi_plan['id'],
             'product_items'       => $this->build_product_items('subscription'),
             'code'                => $wc_subscription->id,
             'installments'        => $this->installments()

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -337,7 +337,7 @@ class Vindi_Payment
 
         $payment_profile = $this->container->api->create_customer_payment_profile($cc_info);
         
-        if (!$payment_profile_id)
+        if (!$payment_profile)
             $this->abort(__('Falha ao registrar o método de pagamento. Verifique os dados e tente novamente.', VINDI_IDENTIFIER), true);
 
         if ($this->gateway->verify_method())

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -291,6 +291,7 @@ class Vindi_Payment
         if ($message = $this->cancel_if_denied_bill_status($subscription['bill'])) {
             $wc_subscription->update_status('cancelled', __($message, VINDI_IDENTIFIER));
             $this->order->update_status('cancelled', __($message, VINDI_IDENTIFIER));
+            $this->container->api->suspend_subscription( $subscription['id'], true );
             $this->abort(__($message, VINDI_IDENTIFIER), true);
         }
 

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -28,6 +28,11 @@ class Vindi_Settings extends WC_Settings_API
     public $api;
 
     /**
+     * @var Vindi_Plan
+     **/
+    public $vindi_plan;
+
+    /**
      * @var Vindi_Logger
      **/
     public $logger;

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -28,11 +28,6 @@ class Vindi_Settings extends WC_Settings_API
     public $api;
 
     /**
-     * @var Vindi_Plan
-     **/
-    public $vindi_plan;
-
-    /**
      * @var Vindi_Logger
      **/
     public $logger;
@@ -276,6 +271,9 @@ class Vindi_Settings extends WC_Settings_API
      */
     public function check_ssl()
     {
+        if ($this->get_is_active_sandbox())
+            return true;
+
         return $this->api->is_merchant_status_trial_or_sandbox()
             || is_ssl();
     }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -49,9 +49,9 @@ class Vindi_Subscription_Status_Handler
      **/
     public function suspend_status($wc_subscription)
     {
-        $vindi_subscription_id = $this->get_vindi_subscription_id($wc_subscription);
+        $subscription_id = $this->get_vindi_subscription_id($wc_subscription);
         if ($this->container->get_synchronism_status()) {
-            $this->container->api->suspend_subscription($vindi_subscription_id);
+            $this->container->api->suspend_subscription($subscription_id);
         }
     }
 
@@ -60,9 +60,9 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_status($wc_subscription)
     {
-        $vindi_subscription_id = $this->get_vindi_subscription_id($wc_subscription);
-        if ($this->container->api->is_subscription_canceled($vindi_subscription_id)) {
-            $this->container->api->suspend_subscription($vindi_subscription_id, true); 
+        $subscription_id = $this->get_vindi_subscription_id($wc_subscription);
+        if ($this->container->api->is_subscription_canceled($subscription_id)) {
+            $this->container->api->suspend_subscription($subscription_id, true); 
         }
     }
 
@@ -71,9 +71,9 @@ class Vindi_Subscription_Status_Handler
      **/
     public function active_status($wc_subscription)
     {
-        $vindi_subscription_id = $this->get_vindi_subscription_id($wc_subscription);
+        $subscription_id = $this->get_vindi_subscription_id($wc_subscription);
         if ($this->container->get_synchronism_status()) {
-            $this->container->api->activate_subscription($vindi_subscription_id);
+            $this->container->api->activate_subscription($subscription_id);
         }
     }
 

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -41,7 +41,7 @@ class Vindi_Subscription_Status_Handler
 
     public function suspend_status($vindi_subscription_id)
     {
-        if($this->container->get_synchronism_status()){
+        if ($this->container->get_synchronism_status()) {
             $this->container->api->suspend_subscription($vindi_subscription_id);
         }
     }
@@ -52,7 +52,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_status($wc_subscription,$new_status)
     {
-        if(!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
+        if (!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
             return $wc_subscription->update_status('cancelled');
         }
         if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {
@@ -65,7 +65,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function active_status($wc_subscription)
     {
-        if($wc_subscription->has_status('on-hold') && $this->container->get_synchronism_status()){
+        if ($wc_subscription->has_status('on-hold') && $this->container->get_synchronism_status()) {
             $this->container->api->activate_subscription($this->vindi_subscription_id);
         }
     }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -55,7 +55,7 @@ class Vindi_Subscription_Status_Handler
         if (!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
             return $wc_subscription->update_status('cancelled');
         }
-        if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {
+        if ($this->container->api->is_subscription_canceled($this->vindi_subscription_id)) {
             $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
         }
     }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -58,10 +58,11 @@ class Vindi_Subscription_Status_Handler
     public function cancelled_status($wc_subscription,$new_status)
     {
         if(false == Vindi_Dependencies::wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
-            $wc_subscription->update_status('cancelled');
+            return $wc_subscription->update_status('cancelled');
         }
-
-        $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
+        if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {
+            $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
+        }
     }
 
     /**

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -52,7 +52,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_status($wc_subscription,$new_status)
     {
-        if(false == Vindi_Dependencies::wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
+        if(!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
             return $wc_subscription->update_status('cancelled');
         }
         if ($this->container->api->get_subscription_status($this->vindi_subscription_id)) {

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -200,7 +200,7 @@ class Vindi_Webhook_Handler
      **/
     private function subscription_canceled($data)
     {
-        $subscription    = $this->find_subscription_by_id($data->subscription->code);
+        $subscription = $this->find_subscription_by_id($data->subscription->code);
         
         if ($this->container->get_synchronism_status()
             && ($subscription->has_status('cancelled')

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -200,16 +200,20 @@ class Vindi_Webhook_Handler
      **/
     private function subscription_canceled($data)
     {
-        $subscription_id = $data->subscription->code;
-        $subscription    = $this->find_subscription_by_id($subscription_id);
-
-        $wc_memberships = Vindi_Dependencies::wc_memberships_are_activated();
-
-        if($wc_memberships || $this->container->get_synchronism_status()){
-            $subscription->update_status('pending-cancel');
-        } else{
-            $subscription->update_status('cancelled');
+        $subscription    = $this->find_subscription_by_id($data->subscription->code);
+        
+        if($this->container->get_synchronism_status()
+            && ($subscription->has_status('cancelled')
+            || $subscription->has_status('pending-cancel')
+            || $subscription->has_status('on-hold'))) {
+            return;
         }
+
+        if (Vindi_Dependencies::wc_memberships_are_activated()) {
+            $subscription->update_status('pending-cancel');
+            return;
+        }
+        $subscription->update_status('cancelled');
     }
 
     /**

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -202,7 +202,7 @@ class Vindi_Webhook_Handler
     {
         $subscription    = $this->find_subscription_by_id($data->subscription->code);
         
-        if($this->container->get_synchronism_status()
+        if ($this->container->get_synchronism_status()
             && ($subscription->has_status('cancelled')
             || $subscription->has_status('pending-cancel')
             || $subscription->has_status('on-hold'))) {

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -209,7 +209,7 @@ class Vindi_Webhook_Handler
             return;
         }
 
-        if (Vindi_Dependencies::wc_memberships_are_activated()) {
+        if ($this->container->dependency->wc_memberships_are_activated()) {
             $subscription->update_status('pending-cancel');
             return;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança
 Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
-WC tested up to: 3.4.4
-Stable Tag: 5.2.0
+WC tested up to: 3.4.5
+Stable Tag: 5.3.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,12 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 5.3.0 - 01/10/2018 =
+- Ajusta performance do checkout
+
+= 5.2.1 - 21/09/2018 =
+- Corrige fluxo de assinatura pós-cancelamento no Woocommerce
+
 = 5.2.0 - 12/09/2018 =
 - Ajusta sincronismo de assinaturas
 - Corrige comportamento das transações recusadas

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.4
-Stable Tag: 5.0.1
+Stable Tag: 5.2.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,10 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 5.2.0 - 11/09/2018 =
+- Ajusta sincronismo de assinaturas
+- Remove consulta adicional na fatura da Vindi após finalização da compra
+
 = 5.0.1 - 29/08/2018 =
 - Corrige erro no cancelamento de assinaturas em algumas versões do PHP.
 

--- a/readme.txt
+++ b/readme.txt
@@ -65,7 +65,6 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 = 5.2.0 - 12/09/2018 =
 - Ajusta sincronismo de assinaturas
 - Corrige comportamento das transações recusadas
-- Remove consulta adicional na fatura da Vindi após finalização da compra
 
 = 5.0.1 - 29/08/2018 =
 - Corrige erro no cancelamento de assinaturas em algumas versões do PHP.

--- a/readme.txt
+++ b/readme.txt
@@ -62,8 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
-= 5.2.0 - 11/09/2018 =
+= 5.2.0 - 12/09/2018 =
 - Ajusta sincronismo de assinaturas
+- Corrige comportamento das transações recusadas
 - Remove consulta adicional na fatura da Vindi após finalização da compra
 
 = 5.0.1 - 29/08/2018 =

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.0.1
+ * Version: 5.2.0
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.0.1';
+        const VERSION = '5.2.0';
 
         /**
 		 * @var string

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,13 +3,13 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.2.0
+ * Version: 5.3.0
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
  * Tested up to: 4.9.8
  * WC requires at least: 3.0.0
- * WC tested up to: 3.4.4
+ * WC tested up to: 3.4.5
  *
  * Text Domain: vindi-woocommerce-subscriptions
  * Domain Path: /languages/


### PR DESCRIPTION
## Motivação
Atualmente o plugin da Vindi realiza em média 12 requisições para realizar uma compra, pois algumas informações são consultadas várias vezes e não persistidas.
O sincronismo de assinaturas não funcionava para a reativação da assinatura.

## Solução Proposta
- Realizar uma refatoração nas consultas e tratamento dos retornos, para diminuir o número de requisições.
- Corrigir o processo de reativação de assinaturas
- Ajuste para utilização para pegar a ID da subscription no método 'get_vindi_subscription_id'
- Ajuste para maior consistência dos status para que novos status (customizados ou futuros) não cancelem automaticamente a assinatura no Vindi.


