### PR TITLE
Corrige comportamento de transação rejeitada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.2.1 - 21/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.1)
+
+### Corrigido
+- Corrige fluxo de assinatura pós-cancelamento no Woocommerce
+
+
 ## [5.2.0 - 12/09/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.2.0)
 
 ### Ajustado

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -291,6 +291,7 @@ class Vindi_Payment
         if ($message = $this->cancel_if_denied_bill_status($subscription['bill'])) {
             $wc_subscription->update_status('cancelled', __($message, VINDI_IDENTIFIER));
             $this->order->update_status('cancelled', __($message, VINDI_IDENTIFIER));
+            $this->container->api->suspend_subscription( $subscription['id'], true );
             $this->abort(__($message, VINDI_IDENTIFIER), true);
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.4
-Stable Tag: 5.2.0
+Stable Tag: 5.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 5.2.1 - 21/09/2018 =
+- Corrige fluxo de assinatura pós-cancelamento no Woocommerce
+
 = 5.2.0 - 12/09/2018 =
 - Ajusta sincronismo de assinaturas
 - Corrige comportamento das transações recusadas

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.2.0
+ * Version: 5.2.1
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.2.0';
+        const VERSION = '5.2.1';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
Ao tentar realizar uma assinatura com dados de cartões rejeitados, a assinatura é cancelada no Wordpress, porém não é enviada nenhuma solicitação para a Vindi.

## Solução Proposta
Enviar o cancelamento também para a Vindi, evitando retentativas de cobrança.