### PR TITLE
Novo ajuste no sincronismo de assinaturas

### DIFF
--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -11,10 +11,6 @@ class Vindi_Subscription_Status_Handler
     {
         $this->container = $container;
 
-        add_action('woocommerce_subscription_status_cancelled',array(
-            &$this, 'cancelled_status'
-        ));
-
         add_action('woocommerce_subscription_status_updated',array(
             &$this, 'filter_pre_status'
         ), 1, 3);
@@ -34,18 +30,18 @@ class Vindi_Subscription_Status_Handler
                 $this->suspend_status($this->get_vindi_subscription_id($wc_subscription));
                 break;
             case 'active':
-            	if( 'on-hold' == $old_status ) {
+            	if( 'on-hold' === $old_status ) {
 		            $this->active_status( $vindi_subscription_id );
 	            }
-                break;           
-            default:
-
-	            if ( ! $this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status ) {
-		            return $wc_subscription->update_status( 'cancelled' );
-	            }
-
-	            $this->cancelled_status( $vindi_subscription_id );
-	            break;
+                break;
+	        case 'cancelled':
+		        $this->cancelled_status( $vindi_subscription_id );
+	        	break;
+	        case 'pending-cancel':
+		        if ( ! $this->container->dependency->wc_memberships_are_activated() ) {
+			        $wc_subscription->update_status( 'cancelled' );
+		        }
+	        	break;
         }
     }
 

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -17,21 +17,25 @@ class Vindi_Subscription_Status_Handler
 
         add_action('woocommerce_subscription_status_updated',array(
             &$this, 'filter_pre_status'
-        ), 1, 2);
+        ), 1, 3);
     }
 
     /**
      * @param WC_Subscription $wc_subscription
      * @param string          $new_status
      **/
-    public function filter_pre_status($wc_subscription, $new_status)
-    {   
+    public function filter_pre_status($wc_subscription, $new_status, $old_status)
+    {
+	    $vindi_subscription_id = $this->get_vindi_subscription_id( $wc_subscription );
+
         switch ($new_status) {
             case 'on-hold':
                 $this->suspend_status($this->get_vindi_subscription_id($wc_subscription));
                 break;
             case 'active':
-                $this->active_status($wc_subscription);
+            	if( 'on-hold' == $old_status ) {
+		            $this->active_status( $vindi_subscription_id );
+	            }
                 break;           
             default:
                 $this->cancelled_status($wc_subscription,$new_status);
@@ -61,12 +65,12 @@ class Vindi_Subscription_Status_Handler
     }
 
     /**
-     * @param WC_Subscription $wc_subscription
+     * @param string $vindi_subscription_id
      **/
-    public function active_status($wc_subscription)
+    public function active_status( $vindi_subscription_id )
     {
-        if ($wc_subscription->has_status('on-hold') && $this->container->get_synchronism_status()) {
-            $this->container->api->activate_subscription($this->vindi_subscription_id);
+        if ( $this->container->get_synchronism_status() ) {
+            $this->container->api->activate_subscription( $vindi_subscription_id );
         }
     }
 

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -1,81 +1,88 @@
 <?php
 
-class Vindi_Subscription_Status_Handler
-{
-    /**
-     * @var Vindi_Settings
-     **/
-    private $container;
-
-    public function __construct(Vindi_Settings $container)
-    {
-        $this->container = $container;
-
-        add_action('woocommerce_subscription_status_updated',array(
-            &$this, 'filter_pre_status'
-        ), 1, 3);
-    }
-
-    /**
-     * @param WC_Subscription $wc_subscription
-     * @param string          $new_status
-     * @param string          $old_status
-     **/
-    public function filter_pre_status($wc_subscription, $new_status, $old_status)
-    {
-	    $vindi_sub_id = $this->get_vindi_subscription_id( $wc_subscription );
-
-        switch ($new_status) {
-            case 'on-hold':
-                $this->suspend_status($this->get_vindi_subscription_id($wc_subscription));
-                break;
-            case 'active':
-            	if( 'on-hold' === $old_status ) {
-		            $this->active_status( $vindi_sub_id );
-	            }
-                break;
-	        case 'cancelled':
-		        $this->cancelled_status( $vindi_sub_id );
-	        	break;
-	        case 'pending-cancel':
-		        if ( ! $this->container->dependency->wc_memberships_are_activated() ) {
-			        $wc_subscription->update_status( 'cancelled' );
-		        }
-	        	break;
-        }
-    }
-
-    public function suspend_status($vindi_sub_id)
-    {
-        if ($this->container->get_synchronism_status()) {
-            $this->container->api->suspend_subscription($vindi_sub_id);
-        }
-    }
-
+class Vindi_Subscription_Status_Handler{
 	/**
-	 * @param string $vindi_subscription_id
+	 * @var Vindi_Settings
 	 **/
-	public function cancelled_status( $vindi_sub_id ) {
-		$this->container->api->suspend_subscription( $vindi_sub_id, true );
+	private $container;
+
+	public function __construct( Vindi_Settings $container ) {
+		$this->container = $container;
+
+		add_action( 'woocommerce_subscription_status_updated', array(
+			&$this,
+			'filter_pre_status'
+		), 1, 3 );
 	}
 
-    /**
-     * @param string $vindi_subscription_id
-     **/
-    public function active_status( $vindi_sub_id )
-    {
-        if ( $this->container->get_synchronism_status() ) {
-            $this->container->api->activate_subscription( $vindi_sub_id );
-        }
-    }
+	/**
+	 * @param WC_Subscription $wc_subscription
+	 * @param string          $new_status
+	 * @param string          $old_status
+	 **/
+	public function filter_pre_status( $wc_subscription, $new_status, $old_status ) {
 
-    /**
-     * @param WC_Subscription $wc_subscription
-     **/
-    public function get_vindi_subscription_id($wc_subscription)
-    {
-        $subscription_id = method_exists($wc_subscription, 'get_id') ? $wc_subscription->get_id() : $wc_subscription->id;
+		$subscription_id = $this->get_vindi_subscription_id( $wc_subscription );
 
-        return end(get_post_meta($subscription_id, 'vindi_wc_subscription_id'));
-    }
+
+		$result = apply_filters( 'vindi_status_handler_filter_pre_status', null, $wc_subscription, $new_status, $old_status, $this );
+
+		if ( null !== $result ) {
+			return;
+		}
+
+		if ( ! $this->container->get_synchronism_status() ) {
+			return;
+		}
+
+
+		switch ( $new_status ) {
+			case 'on-hold':
+				$this->suspend_status( $subscription_id );
+				break;
+			case 'active':
+				$this->active_status( $subscription_id );
+				break;
+			case 'pending-cancel':
+				if ( ! $this->container->dependency->wc_memberships_are_activated() ) {
+					$wc_subscription->update_status( 'cancelled' );
+				}
+				break;
+			default:
+				$this->suspend_status( $subscription_id );
+				break;
+		}
+
+	}
+
+	public function suspend_status( $subscription_id ) {
+		$this->container->api->suspend_subscription( $subscription_id );
+	}
+
+	/**
+	 * @param string $subscription_id
+	 **/
+	public function cancelled_status( $subscription_id ) {
+		$this->container->api->suspend_subscription( $subscription_id, true );
+	}
+
+	/**
+	 * @param string $subscription_id
+	 **/
+	public function active_status( $subscription_id ) {
+		$this->container->api->activate_subscription( $subscription_id );
+	}
+
+	/**
+	 * @param WC_Subscription $wc_subscription
+	 *
+	 * @return string vindi_subscription_ic
+	 **/
+	public function get_vindi_subscription_id( $wc_subscription ) {
+		$subscription_id = method_exists( $wc_subscription, 'get_id' )
+			? $wc_subscription->get_id()
+			: $wc_subscription->id;
+
+		return end( get_post_meta( $subscription_id, 'vindi_wc_subscription_id' ) );
+	}
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -38,8 +38,13 @@ class Vindi_Subscription_Status_Handler
 	            }
                 break;           
             default:
-                $this->cancelled_status($wc_subscription,$new_status);
-                break;
+
+	            if ( ! $this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status ) {
+		            return $wc_subscription->update_status( 'cancelled' );
+	            }
+
+	            $this->cancelled_status( $vindi_subscription_id );
+	            break;
         }
     }
 
@@ -50,19 +55,14 @@ class Vindi_Subscription_Status_Handler
         }
     }
 
-    /**
-     * @param WC_Subscription $wc_subscription
-     * @param string          $new_status
-     **/
-    public function cancelled_status($wc_subscription,$new_status = 'cancelled')
-    {
-        if (!$this->container->dependency->wc_memberships_are_activated() && 'pending-cancel' === $new_status) {
-            return $wc_subscription->update_status('cancelled');
-        }
-        if ($this->container->api->is_subscription_canceled($this->vindi_subscription_id)) {
-            $this->container->api->suspend_subscription($this->vindi_subscription_id, true); 
-        }
-    }
+	/**
+	 * @param string $vindi_subscription_id
+	 **/
+	public function cancelled_status( $vindi_subscription_id ) {
+		if ( $this->container->api->is_subscription_canceled( $vindi_subscription_id ) ) {
+			$this->container->api->suspend_subscription( $vindi_subscription_id, true );
+		}
+	}
 
     /**
      * @param string $vindi_subscription_id

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -78,6 +78,8 @@ class Vindi_Subscription_Status_Handler
      **/
     public function get_vindi_subscription_id($wc_subscription)
     {
-        return end(get_post_meta($wc_subscription->id, 'vindi_wc_subscription_id'));
+        $subscription_id = method_exists($wc_subscription, 'get_id') ? $wc_subscription->get_id() : $wc_subscription->id;
+
+        return end(get_post_meta($subscription_id, 'vindi_wc_subscription_id'));
     }
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -24,7 +24,6 @@ class Vindi_Subscription_Status_Handler{
 
 		$subscription_id = $this->get_vindi_subscription_id( $wc_subscription );
 
-
 		$result = apply_filters( 'vindi_status_handler_filter_pre_status', null, $wc_subscription, $new_status, $old_status, $this );
 
 		if ( null !== $result ) {
@@ -35,7 +34,6 @@ class Vindi_Subscription_Status_Handler{
 			return;
 		}
 
-
 		switch ( $new_status ) {
 			case 'on-hold':
 				$this->suspend_status( $subscription_id );
@@ -43,16 +41,15 @@ class Vindi_Subscription_Status_Handler{
 			case 'active':
 				$this->active_status( $subscription_id );
 				break;
+			case 'cancelled':
+				$this->cancelled_status( $subscription_id );
+				break;
 			case 'pending-cancel':
 				if ( ! $this->container->dependency->wc_memberships_are_activated() ) {
 					$wc_subscription->update_status( 'cancelled' );
 				}
 				break;
-			default:
-				$this->suspend_status( $subscription_id );
-				break;
 		}
-
 	}
 
 	public function suspend_status( $subscription_id ) {

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -23,6 +23,7 @@ class Vindi_Subscription_Status_Handler
     /**
      * @param WC_Subscription $wc_subscription
      * @param string          $new_status
+     * @param string          $old_status
      **/
     public function filter_pre_status($wc_subscription, $new_status, $old_status)
     {
@@ -59,9 +60,7 @@ class Vindi_Subscription_Status_Handler
 	 * @param string $vindi_subscription_id
 	 **/
 	public function cancelled_status( $vindi_subscription_id ) {
-		if ( $this->container->api->is_subscription_canceled( $vindi_subscription_id ) ) {
-			$this->container->api->suspend_subscription( $vindi_subscription_id, true );
-		}
+		$this->container->api->suspend_subscription( $vindi_subscription_id, true );
 	}
 
     /**

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -23,7 +23,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function filter_pre_status($wc_subscription, $new_status, $old_status)
     {
-	    $vindi_subscription_id = $this->get_vindi_subscription_id( $wc_subscription );
+	    $vindi_sub_id = $this->get_vindi_subscription_id( $wc_subscription );
 
         switch ($new_status) {
             case 'on-hold':
@@ -31,11 +31,11 @@ class Vindi_Subscription_Status_Handler
                 break;
             case 'active':
             	if( 'on-hold' === $old_status ) {
-		            $this->active_status( $vindi_subscription_id );
+		            $this->active_status( $vindi_sub_id );
 	            }
                 break;
 	        case 'cancelled':
-		        $this->cancelled_status( $vindi_subscription_id );
+		        $this->cancelled_status( $vindi_sub_id );
 	        	break;
 	        case 'pending-cancel':
 		        if ( ! $this->container->dependency->wc_memberships_are_activated() ) {
@@ -45,27 +45,27 @@ class Vindi_Subscription_Status_Handler
         }
     }
 
-    public function suspend_status($vindi_subscription_id)
+    public function suspend_status($vindi_sub_id)
     {
         if ($this->container->get_synchronism_status()) {
-            $this->container->api->suspend_subscription($vindi_subscription_id);
+            $this->container->api->suspend_subscription($vindi_sub_id);
         }
     }
 
 	/**
 	 * @param string $vindi_subscription_id
 	 **/
-	public function cancelled_status( $vindi_subscription_id ) {
-		$this->container->api->suspend_subscription( $vindi_subscription_id, true );
+	public function cancelled_status( $vindi_sub_id ) {
+		$this->container->api->suspend_subscription( $vindi_sub_id, true );
 	}
 
     /**
      * @param string $vindi_subscription_id
      **/
-    public function active_status( $vindi_subscription_id )
+    public function active_status( $vindi_sub_id )
     {
         if ( $this->container->get_synchronism_status() ) {
-            $this->container->api->activate_subscription( $vindi_subscription_id );
+            $this->container->api->activate_subscription( $vindi_sub_id );
         }
     }
 


### PR DESCRIPTION
## Motivação
Melhoria da sincronia: pensei melhor e faz sentido que qualquer status que não seja 'active' suspenda automaticamente a assinatura no Vindi.

## Solução Proposta
- Comportamento default de suspender a Assinatura.
- Filtro de pre-processamento para que plugins e temas possam alterar esse comportamento.
- Checagem do sincronismo de status no início da função simplificando o restante do código.

