### PR TITLE
Corrige falha na verificação do certificado SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.3.1 - 05/10/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.3.1)
+
+### Corrigido
+- Corrige falha na verificação do certificado SSL
+
+
 ## [5.3.0 - 01/10/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.3.0)
 
 ### Corrigido

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -681,9 +681,12 @@ class Vindi_API
      */
     public function is_merchant_status_trial_or_sandbox()
     {
+        if ('yes' === $this->sandbox)
+            return true;
+
         $merchant = $this->get_merchant();
         
-        if ('trial' === $merchant['status'] || 'yes' === $this->sandbox)
+        if ('trial' === $merchant['status'])
             return true;
         
         return false;

--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -643,9 +643,9 @@ class Vindi_API
      * Make an API request to retrieve informations about the Merchant.
      * @return array|bool|mixed
      */
-    public function get_merchant()
+    public function get_merchant($is_config = false)
     {
-        if (false === ($merchant = get_transient('vindi_merchant'))) {
+        if (false === ($merchant = get_transient('vindi_merchant')) || $is_config) {
             $response = $this->request('merchant', 'GET');
 
             if (! $response || ! $response['merchant'])
@@ -679,12 +679,12 @@ class Vindi_API
      * Check to see if Merchant Status is Trial or Sandbox Merchant.
      * @return boolean
      */
-    public function is_merchant_status_trial_or_sandbox()
+    public function is_merchant_status_trial_or_sandbox($is_config = false)
     {
         if ('yes' === $this->sandbox)
             return true;
 
-        $merchant = $this->get_merchant();
+        $merchant = $is_config ? $this->get_merchant($is_config) : $this->get_merchant();
         
         if ('trial' === $merchant['status'])
             return true;
@@ -749,6 +749,7 @@ class Vindi_API
 			}
 		}
 
+        set_transient('vindi_merchant', $response_body_array['merchant'], 1 * HOUR_IN_SECONDS);
 		return true;
     }
 

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -271,9 +271,6 @@ class Vindi_Settings extends WC_Settings_API
      */
     public function check_ssl()
     {
-        if ($this->get_is_active_sandbox())
-            return true;
-
         return $this->api->is_merchant_status_trial_or_sandbox()
             || is_ssl();
     }

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -271,7 +271,7 @@ class Vindi_Settings extends WC_Settings_API
      */
     public function check_ssl()
     {
-        return $this->api->is_merchant_status_trial_or_sandbox()
+        return $this->api->is_merchant_status_trial_or_sandbox(true)
             || is_ssl();
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.5
-Stable Tag: 5.3.0
+Stable Tag: 5.3.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+= 5.3.1 - 05/10/2018 =
+- Corrige falha na verificação do certificado SSL
+
 = 5.3.0 - 01/10/2018 =
 - Ajusta performance do checkout
 

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.3.0
+ * Version: 5.3.1
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.2.1';
+        const VERSION = '5.3.1';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
A validação do certificado SSL não estava sendo realizada, pois a validação do modo Sandbox estava retornando true por default.

## Solução Proposta
Alterar a validação na classe API, para verificar se a opção Sandbox está habilitada; Se não, realizar uma requisição para validar o status.