### PR TITLE
Fix/Validação dos plugins de dependência

### DIFF
--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -102,7 +102,7 @@ class Vindi_Dependencies
     **/
     public static function verify_version_of_plugin($plugin)
     {
-        $plugin_data = get_plugin_data(ABSPATH . "wp-content/plugins/" . $plugin['path']);
+        $plugin_data = get_plugin_data(plugin_dir_path(__DIR__) . "../" . $plugin['path']);
         $version_match = $plugin['plugin']['version'];
         $version_compare = version_compare(
                 $plugin_data['Version'],


### PR DESCRIPTION
## Motivação
Atualmente o plugin possui a dependência do ```WooCommerce``` e ```Extra Checkout Fields For Brazil```, existe uma validação da instalação e versão desses plugins na classe ```class-vindi-dependencies```, encontramos um bug causado pelo método utilizado para encontrar os paths dos plugins.

## Solução Proposta
A estrutura de diretórios do wordpress.com é diferente do wordpress.org, optamos por usar o método ```plugin_dir_path``` ao invés do ```ABSPATH```.