### PR TITLE
Ajusta arquivos para versão 5.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Corrigido
 - Corrige instalação no ambiente Wordpress.com
 
+
 ## [5.3.2 - 08/10/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.3.2)
 
 ### Corrigido

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -16,8 +16,6 @@ extensions:
   - Codeception\Command\GenerateWPAjax
   - Codeception\Command\GenerateWPCanonical
   - Codeception\Command\GenerateWPXMLRPC
-  - Codeception\Command\DbSnapshot
-  - tad\Codeception\Command\SearchReplace
 params:
 - .env
 coverage:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require-dev": {
-    "lucatume/wp-browser": "^2.1",
+    "lucatume/wp-browser": "^2.2",
     "codeception/specify": "^1.0",
     "codeception/verify": "^1.0"
   },

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.5
-Stable Tag: 5.3.2
+Stable Tag: 5.3.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,10 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+
+= 5.3.3 - 30/11/2018 =
+- Corrige instalação no ambiente Wordpress.com
+
 = 5.3.2 - 08/10/2018 =
 - Corrige cache dos métodos de pagamento
 - Corrige data do próximo pagamento para as assinaturas

--- a/tests/acceptance/Buy Product Credit Card.feature
+++ b/tests/acceptance/Buy Product Credit Card.feature
@@ -20,7 +20,7 @@ Funcionalidade: Comprar um produto com cartão de crédito
     Então Eu vejo "R$25,00"
     E Eu preencho dados do cartão de crédito
     E Eu clico em Finalizar compra
-    E Eu espero "10" segundos
+    E Eu espero "15" segundos
     Então Eu vejo "Pedido recebido"
     Então Eu vejo "R$25,00"
     Então Eu vejo "Cartão de Crédito"

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.3.2
+ * Version: 5.3.3
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.3.2';
+        const VERSION = '5.3.3';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
Foi criado uma nova versão do Vindi-woocommerce-subscription e será necessário ajustar os testes e arquivos de versão para subir no marktplace

## Solução Proposta
Ajuste dos arquivos de versão do marktplace e ajustar os testes para ter segurança ao subir
