### PR TITLE
Adiciona compatibilidade com frete único

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.4.0 - 15/01/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.4.0)
+
+### Adicionado
+- Adiciona compatibilidade com frete único
+
+
 ## [5.3.3 - 30/11/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.3.3)
 
 ### Corrigido

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -360,22 +360,10 @@ class Vindi_Payment
      **/
     private function return_cycle_from_product_type($item)
     {
-        if ($item['type'] == 'shipping' || $item['type'] == 'tax') {
-
-            /* Define a duração como 1 se a configuração 'One Time Shipping' estiver habilitada */
-            if ($this->is_one_time_shipping($item->get_product())) {
-                return 1;
-            }
-
-            /* Define como duração permanente */
-            return null;
-        }
-
         if (!$this->is_subscription_type($item->get_product())
             || $this->is_one_time_shipping($item->get_product())) {
             return 1;
         }
-
         return null;
     }
 

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -358,16 +358,33 @@ class Vindi_Payment
     /**
      * @param array $item
      **/
-  private function return_cycle_from_product_type($item)
+    private function return_cycle_from_product_type($item)
     {
-        if ($item['type'] == 'shipping' || $item['type'] == 'tax')
+        if ($item['type'] == 'shipping' || $item['type'] == 'tax') {
+
+            /* Define a duração como 1 se a configuração 'One Time Shipping' estiver habilitada */
+            if ($this->is_one_time_shipping($item->get_product())) {
+                return 1;
+            }
+
+            /* Define como duração permanente */
             return null;
-        
-        if(!$this->is_subscription_type($item->get_product())) {
+        }
+
+        if (!$this->is_subscription_type($item->get_product())
+            || $this->is_one_time_shipping($item->get_product())) {
             return 1;
         }
 
         return null;
+    }
+
+    /**
+     * @param WC_Product $item
+     */
+    private function is_one_time_shipping($item)
+    {
+        return reset(get_post_meta($item->id)['_subscription_one_time_shipping']) == 'yes';
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.5
-Stable Tag: 5.3.3
+Stable Tag: 5.4.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+
+= 5.4.0 - 15/01/2019 =
+- Adiciona compatibilidade com frete único
 
 = 5.3.3 - 30/11/2018 =
 - Corrige instalação no ambiente Wordpress.com

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.3.3
+ * Version: 5.4.0
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.3.3';
+        const VERSION = '5.4.0';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
Possibilitar aos clientes configurar frete único para produtos do tipo assinatura.

## Solução Proposta
Aproveitar função disponível no WooCommerce que de certa forma deveria realizar essa função, porém não era compatível com o nosso plugin.