### PR TITLE
Torna cobrança única de frete/taxa opcional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Notas das versões
 
+## [5.4.1 - 21/01/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.4.1)
+
+### Adicionado
+- Adiciona opção para cobranças únicas de fretes e taxas
+
+
 ## [5.4.0 - 15/01/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.4.0)
 
 ### Adicionado
-- Adiciona compatibilidade com frete único
+- Adiciona compatibilidade com entrega única
 
 
 ## [5.3.3 - 30/11/2018](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.3.3)

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -360,8 +360,12 @@ class Vindi_Payment
      **/
     private function return_cycle_from_product_type($item)
     {
-        if (!$this->is_subscription_type($item->get_product())
-            || $this->is_one_time_shipping($item->get_product())) {
+        if ($item['type'] == 'shipping' || $item['type'] == 'tax') {
+            if ($this->container->get_shipping_and_tax_config())
+                return 1;
+        }
+        elseif (!$this->is_subscription_type(wc_get_product($item['product_id']))
+            || $this->is_one_time_shipping(wc_get_product($item['product_id']))) {
             return 1;
         }
         return null;

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -151,6 +151,13 @@ class Vindi_Settings extends WC_Settings_API
                 'description'      => __('Envia as alterações de status nas assinaturas do WooCommerce para Vindi.', VINDI_IDENTIFIER),
                 'default'          => 'no',
             ),
+            'shipping_and_tax_config'  => array(
+                'title'            => __('Cobrança única', VINDI_IDENTIFIER),
+                'type'             => 'checkbox',
+                'label'      => __('Ativar cobrança única para fretes e taxas', VINDI_IDENTIFIER),
+                'description'      => __('Fretes e Taxas serão cobrados somente no primeiro ciclo de uma assinatura', VINDI_IDENTIFIER),
+                'default'          => 'no',
+            ),
 			'testing'              => array(
 				'title'            => __('Testes', 'vindi-woocommerce'),
 				'type'             => 'title',
@@ -230,6 +237,15 @@ class Vindi_Settings extends WC_Settings_API
     public function get_synchronism_status()
     {
         return 'yes' === $this->settings['vindi_synchronism'];
+    }
+
+    /**
+     * Get Vindi Shipping and Tax config
+     * @return string
+     **/
+    public function get_shipping_and_tax_config()
+    {
+        return 'yes' === $this->settings['shipping_and_tax_config'];
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.5
-Stable Tag: 5.4.0
+Stable Tag: 5.4.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -63,8 +63,11 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 
 == Changelog ==
 
+= 5.4.1 - 21/01/2019 =
+- Adiciona opção para cobranças únicas de fretes e taxas
+
 = 5.4.0 - 15/01/2019 =
-- Adiciona compatibilidade com frete único
+- Adiciona compatibilidade com entrega única
 
 = 5.3.3 - 30/11/2018 =
 - Corrige instalação no ambiente Wordpress.com

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.4.0
+ * Version: 5.4.1
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.4.0';
+        const VERSION = '5.4.1';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
- As alterações do PR #115 tornaram padrão com o uso da opção 'one_time_shipping' a cobrança de frente uma única vez.
Alguns clientes informaram que esse comportamento deve ser opcional, pois existem diferenças entre cobrar um produto um único ciclo, e cobrar o frete um único ciclo.
- O método **get_product()** foi descontinuado, e deve ser substituído para manter o funcionamento do plugin.

## Solução Proposta
- Disponibilizar um toggle para o cliente com a função de cobrança de frete/taxa em um único ciclo
- Substituir o método **get_product()** para **wc_get_product(WC_Product[$id])**