### PR TITLE
Utiliza cache dos dados do merchant no Checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.4.2 - 13/03/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.4.3)
+
+### Ajustado
+- Ajusta validação dos dados da empresa durante o checkout
+
+
 ## [5.4.1 - 21/01/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.4.1)
 
 ### Adicionado

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -287,7 +287,7 @@ class Vindi_Settings extends WC_Settings_API
      */
     public function check_ssl()
     {
-        return $this->api->is_merchant_status_trial_or_sandbox(true)
+        return $this->api->is_merchant_status_trial_or_sandbox()
             || is_ssl();
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 4.9.8
 WC requires at least: 3.0.0
 WC tested up to: 3.4.5
-Stable Tag: 5.4.1
+Stable Tag: 5.4.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+
+= 5.4.2 - 13/03/2019 =
+- Ajusta validação dos dados da empresa durante o checkout
 
 = 5.4.1 - 21/01/2019 =
 - Adiciona opção para cobranças únicas de fretes e taxas

--- a/templates/admin-settings.html.php
+++ b/templates/admin-settings.html.php
@@ -19,7 +19,7 @@
     $merchant = false;
     $api_key  = $settings->get_api_key();
     if(!empty($api_key))
-        $merchant = $settings->api->get_merchant();
+        $merchant = $settings->api->get_merchant(true);
 
 ?>
 <div class="below-h2 <?php echo $merchant !== false ? 'updated' : 'error'; ?>">

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.4.1
+ * Version: 5.4.2
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.4.1';
+        const VERSION = '5.4.2';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
No checkout estão sendo realizadas muitas requisições para API da Vindi (_GET/merchant_)

## Solução Proposta
Foi ajustada a troca de um parâmetro para uso de cache "transient"