### PR TITLE
Adiciona plano da Vindi nas Assinaturas Variáveis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.5.0 - 04/06/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.0)
+
+### Adicionado
+- Adiciona plano da Vindi para assinaturas do tipo variável
+
+
 ## [5.4.2 - 13/03/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.4.3)
 
 ### Ajustado

--- a/assets/js/simple-subscription-fields.js
+++ b/assets/js/simple-subscription-fields.js
@@ -8,8 +8,6 @@
         var id   = $(this).val();
         var plan = plan_infos[id];
 
-        console.log('#_subscription_period_interval');
-        
         $("#_subscription_period_interval").val(plan.interval_count);
         $("#_subscription_period").val(plan.interval.toString().replace(/s/g, ''));
         $("#_subscription_length").val(plan.billing_cycles || 0);
@@ -18,8 +16,6 @@
       $(document).on("change", ".variable_vindi_subscription_plan", function(){
         var id   = $(this).val();
         var plan = plan_infos[id];
-
-        console.log($(this).parents(".data").find(".wc_input_subscription_period_interval"));
 
         $(this).parents(".data").find(".wc_input_subscription_period_interval").val(plan.interval_count);
         $(this).parents(".data").find(".wc_input_subscription_period").val(plan.interval.toString().replace(/s/g, ''));

--- a/assets/js/simple-subscription-fields.js
+++ b/assets/js/simple-subscription-fields.js
@@ -8,11 +8,22 @@
         var id   = $(this).val();
         var plan = plan_infos[id];
 
-        console.log($(".wc_input_subscription_period_interval"));
+        console.log('#_subscription_period_interval');
         
-        $(".wc_input_subscription_period_interval").val(plan.interval_count);
-        $(".wc_input_subscription_period").val(plan.interval.toString().replace(/s/g, ''));
-        $(".wc_input_subscription_length").val(plan.billing_cycles || 0);
+        $("#_subscription_period_interval").val(plan.interval_count);
+        $("#_subscription_period").val(plan.interval.toString().replace(/s/g, ''));
+        $("#_subscription_length").val(plan.billing_cycles || 0);
+      });
+
+      $(document).on("change", ".variable_vindi_subscription_plan", function(){
+        var id   = $(this).val();
+        var plan = plan_infos[id];
+
+        console.log($(this).parents(".data").find(".wc_input_subscription_period_interval"));
+
+        $(this).parents(".data").find(".wc_input_subscription_period_interval").val(plan.interval_count);
+        $(this).parents(".data").find(".wc_input_subscription_period").val(plan.interval.toString().replace(/s/g, ''));
+        $(this).parents(".data").find(".wc_input_subscription_length").val(plan.billing_cycles || 0);
       });
     });
   }(jQuery)

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -68,7 +68,11 @@ class Vindi_Payment
 
         foreach($items as $item) {
             $product    = $this->order->get_product_from_item($item);
-            $vindi_plan = get_post_meta($product->id, 'vindi_subscription_plan', true);
+
+            if( isset($item['variation_id']) && $item['variation_id'] != 0)
+                $vindi_plan = get_post_meta($item['variation_id'], 'vindi_subscription_plan', true);
+            else
+                $vindi_plan = get_post_meta($product->id, 'vindi_subscription_plan', true);
 
             if ($this->is_subscription_type($product) AND !empty($vindi_plan))
                 return $vindi_plan;

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -69,7 +69,7 @@ class Vindi_Payment
         foreach($items as $item) {
             $product    = $this->order->get_product_from_item($item);
 
-            if ( isset($item['variation_id']) && $item['variation_id'] != 0) {
+            if (isset($item['variation_id']) && $item['variation_id'] != 0) {
                 $vindi_plan = get_post_meta($item['variation_id'], 'vindi_variable_subscription_plan', true);
                 if (empty($vindi_plan) || !is_numeric($vindi_plan) || is_null($vindi_plan) || $vindi_plan == 0){
                     $vindi_plan = get_post_meta($product->id, 'vindi_subscription_plan', true);

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -69,7 +69,7 @@ class Vindi_Payment
         foreach($items as $item) {
             $product    = $this->order->get_product_from_item($item);
 
-            if( isset($item['variation_id']) && $item['variation_id'] != 0){
+            if ( isset($item['variation_id']) && $item['variation_id'] != 0) {
                 $vindi_plan = get_post_meta($item['variation_id'], 'vindi_variable_subscription_plan', true);
                 if (empty($vindi_plan) || !is_numeric($vindi_plan) || is_null($vindi_plan) || $vindi_plan == 0){
                     $vindi_plan = get_post_meta($product->id, 'vindi_subscription_plan', true);

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -70,8 +70,8 @@ class Vindi_Payment
             $product    = $this->order->get_product_from_item($item);
 
             if( isset($item['variation_id']) && $item['variation_id'] != 0){
-                $vindi_plan = get_post_meta($item['variation_id'], 'vindi_subscription_plan', true);
-                if (empty($vindi_plan) || !is_numeric($vindi_plan) || is_null($vindi_plan)){
+                $vindi_plan = get_post_meta($item['variation_id'], 'vindi_variable_subscription_plan', true);
+                if (empty($vindi_plan) || !is_numeric($vindi_plan) || is_null($vindi_plan) || $vindi_plan == 0){
                     $vindi_plan = get_post_meta($product->id, 'vindi_subscription_plan', true);
                 }
             }

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -69,8 +69,12 @@ class Vindi_Payment
         foreach($items as $item) {
             $product    = $this->order->get_product_from_item($item);
 
-            if( isset($item['variation_id']) && $item['variation_id'] != 0)
+            if( isset($item['variation_id']) && $item['variation_id'] != 0){
                 $vindi_plan = get_post_meta($item['variation_id'], 'vindi_subscription_plan', true);
+                if (empty($vindi_plan) || !is_numeric($vindi_plan) || is_null($vindi_plan)){
+                    $vindi_plan = get_post_meta($product->id, 'vindi_subscription_plan', true);
+                }
+            }
             else
                 $vindi_plan = get_post_meta($product->id, 'vindi_subscription_plan', true);
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: erico.pedroso, tales.galvao.vindi, wnarde, lyoncesar, laertejr, rt
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions, vindi-woocommerce
 Requires at least: 4.4
-Tested up to: 4.9.8
+Tested up to: 5.2.1
 WC requires at least: 3.0.0
-WC tested up to: 3.4.5
-Stable Tag: 5.4.2
+WC tested up to: 3.6.4
+Stable Tag: 5.5.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+
+= 5.5.0 - 04/06/2019 =
+- Adiciona plano da Vindi para assinaturas do tipo variável
 
 = 5.4.2 - 13/03/2019 =
 - Ajusta validação dos dados da empresa durante o checkout

--- a/templates/admin-simple-product-subscription-fields.html.php
+++ b/templates/admin-simple-product-subscription-fields.html.php
@@ -19,7 +19,7 @@
 
 <?php
 
-    if(preg_match('/variable-subscription/', $product_type)) {
+    if (preg_match('/variable-subscription/', $product_type)) {
         $label = __('Plano da Vindi Padrão', VINDI_IDENTIFIER);
         $description = __('Selecione o plano da Vindi padrão que deseja relacionar a esse produto caso não especifique na variação', VINDI_IDENTIFIER);
     } else {

--- a/templates/admin-simple-product-subscription-fields.html.php
+++ b/templates/admin-simple-product-subscription-fields.html.php
@@ -1,0 +1,32 @@
+<?php if (!defined( 'ABSPATH')) exit; ?>
+<style type="text/css">
+    ._subscription_sign_up_fee_field,
+    ._subscription_trial_length_field,
+    ._subscription_trial_period_field,
+    ._subscription_period_interval_field,
+    ._subscription_period_field,
+    ._subscription_length_field,
+    .wc_input_subscription_intial_price,
+    .wc_input_subscription_trial_length,
+    .wc_input_subscription_trial_period,
+    .variable_subscription_trial {
+        display: none !important;
+    }
+</style>
+<div class="options_group vindi-subscription_pricing show_if_subscription">
+
+<?php
+    woocommerce_wp_select(array(
+        'id'                 => 'vindi_subscription_plan',
+        'label'              => __('Plano da Vindi', VINDI_IDENTIFIER),
+        'options'            => $plans['names'],
+        'description'        => __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER),
+        'desc_tip'           => true,
+        'value'              => $selected_plan,
+        'custom_attributes'  => array(
+            'data-plan-info' => json_encode($plans['infos'])
+        )
+    ));
+?>
+</div>
+<div class="show_if_subscription clear"></div>

--- a/templates/admin-simple-product-subscription-fields.html.php
+++ b/templates/admin-simple-product-subscription-fields.html.php
@@ -15,14 +15,23 @@
         display: none !important;
     }
 </style>
-<div class="options_group vindi-subscription_pricing show_if_subscription">
+<div class="options_group vindi-subscription_pricing show_if_subscription show_if_variable-subscription">
 
 <?php
+
+    if(preg_match('/variable-subscription/', $product_type)) {
+        $label = __('Plano da Vindi Padrão', VINDI_IDENTIFIER);
+        $description = __('Selecione o plano da Vindi padrão que deseja relacionar a esse produto caso não especifique na variação', VINDI_IDENTIFIER);
+    } else {
+        $label = __('Plano da Vindi', VINDI_IDENTIFIER);
+        $description = __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER);
+    }
+
     woocommerce_wp_select(array(
         'id'                 => 'vindi_subscription_plan',
-        'label'              => __('Plano da Vindi', VINDI_IDENTIFIER),
+        'label'              => $label,
         'options'            => $plans['names'],
-        'description'        => __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER),
+        'description'        => $description,
         'desc_tip'           => true,
         'value'              => $selected_plan,
         'custom_attributes'  => array(

--- a/templates/admin-simple-product-subscription-fields.html.php
+++ b/templates/admin-simple-product-subscription-fields.html.php
@@ -6,6 +6,8 @@
     ._subscription_period_interval_field,
     ._subscription_period_field,
     ._subscription_length_field,
+    .wc_input_subscription_period,
+    .wc_input_subscription_period_interval,
     .wc_input_subscription_intial_price,
     .wc_input_subscription_trial_length,
     .wc_input_subscription_trial_period,

--- a/templates/admin-simple-product-subscription-fields.html.php
+++ b/templates/admin-simple-product-subscription-fields.html.php
@@ -20,8 +20,8 @@
 <?php
 
     if (preg_match('/variable-subscription/', $product_type)) {
-        $label = __('Plano da Vindi Padrão', VINDI_IDENTIFIER);
-        $description = __('Selecione o plano da Vindi padrão que deseja relacionar a esse produto caso não especifique na variação', VINDI_IDENTIFIER);
+        $label = __('Plano padrão da Vindi', VINDI_IDENTIFIER);
+        $description = __('Selecione o plano padrão da Vindi que deseja relacionar a esse produto caso não especifique na variação', VINDI_IDENTIFIER);
     } else {
         $label = __('Plano da Vindi', VINDI_IDENTIFIER);
         $description = __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER);

--- a/templates/admin-variable-product-subscription-fields.html.php
+++ b/templates/admin-variable-product-subscription-fields.html.php
@@ -6,8 +6,6 @@
     ._subscription_period_interval_field,
     ._subscription_period_field,
     ._subscription_length_field,
-    .wc_input_subscription_period,
-    .wc_input_subscription_period_interval,
     .wc_input_subscription_intial_price,
     .wc_input_subscription_trial_length,
     .wc_input_subscription_trial_period,
@@ -15,12 +13,11 @@
         display: none !important;
     }
 </style>
-
-<div class="options_group vindi-subscription_pricing show_if_subscription show_if_variable-subscription">
+<div class="options_group vindi-subscription_pricing show_if_variable-subscription">
 
 <?php
     woocommerce_wp_select(array(
-        'id'                 => 'vindi_subscription_plan',
+        'id'                 => 'vindi_subscription_plan[' . $loop . ']',
         'label'              => __('Plano da Vindi', VINDI_IDENTIFIER),
         'options'            => $plans['names'],
         'description'        => __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER),

--- a/templates/admin-variable-product-subscription-fields.html.php
+++ b/templates/admin-variable-product-subscription-fields.html.php
@@ -3,7 +3,7 @@
 
 <?php
     woocommerce_wp_select(array(
-        'id'                 => 'vindi_subscription_plan[' . $loop . ']',
+        'id'                 => 'vindi_variable_subscription_plan[' . $loop . ']',
         'label'              => __('Plano da Vindi', VINDI_IDENTIFIER),
         'options'            => $plans['names'],
         'description'        => __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER),

--- a/templates/admin-variable-product-subscription-fields.html.php
+++ b/templates/admin-variable-product-subscription-fields.html.php
@@ -1,18 +1,4 @@
 <?php if (!defined( 'ABSPATH')) exit; ?>
-<style type="text/css">
-    ._subscription_sign_up_fee_field,
-    ._subscription_trial_length_field,
-    ._subscription_trial_period_field,
-    ._subscription_period_interval_field,
-    ._subscription_period_field,
-    ._subscription_length_field,
-    .wc_input_subscription_intial_price,
-    .wc_input_subscription_trial_length,
-    .wc_input_subscription_trial_period,
-    .variable_subscription_trial {
-        display: none !important;
-    }
-</style>
 <div class="options_group vindi-subscription_pricing show_if_variable-subscription">
 
 <?php
@@ -23,9 +9,7 @@
         'description'        => __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER),
         'desc_tip'           => true,
         'value'              => $selected_plan,
-        'custom_attributes'  => array(
-            'data-plan-info' => json_encode($plans['infos'])
-        )
+        'class'              => 'select short variable_vindi_subscription_plan'
     ));
 ?>
 </div>

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -134,6 +134,10 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                     array(&$this, 'variable_subscription_custom_fields')
                 , 10, 3);
 
+                add_action('woocommerce_process_product_meta',
+                    array(&$this, 'save_subscription_meta')
+                , 20);
+
                 add_action('save_post',
                     array(&$this, 'save_subscription_meta')
                 , 20);

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -240,17 +240,17 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             $subscription_period          = wc_clean($_POST['_subscription_period']);
             $subscription_length          = wc_clean($_POST['_subscription_length']);
 
-            if(empty($subscription_period_interval)) {
+            if (empty($subscription_period_interval)) {
                 return;
             }
 
-            if($subscription_period_interval % 12 == 0) {
+            if ($this->is_yearly_plan($subscription_period_interval, $subscription_period)) {
                 $years_interval = (int) $subscription_period_interval / 12;
                 update_post_meta($post_id, '_subscription_period_interval', $years_interval);
                 update_post_meta($post_id, '_subscription_period', 'year');
                 update_post_meta($post_id, 'vindi_subscription_period_interval', $years_interval);
                 update_post_meta($post_id, 'vindi_subscription_period', 'year');
-            } else if ($subscription_period_interval % 7 == 0 && $subscription_period == 'day') {
+            } else if ($this->is_weekly_plan($subscription_period_interval, $subscription_period)) {
                 $weeks_interval = (int) $subscription_period_interval / 7;
                 update_post_meta($post_id, '_subscription_period_interval', $weeks_interval);
                 update_post_meta($post_id, '_subscription_period', 'week');
@@ -277,13 +277,13 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             $child_subscription_length          = wc_clean($_POST['variable_subscription_length'][$i]);
 
             update_post_meta($variation_id, '_subscription_length', $child_subscription_length);
-            if($child_subscription_period_interval % 12 == 0) {
+            if($this->is_yearly_plan($child_subscription_period_interval, $child_subscription_period)) {
                 $child_years_interval = (int) $child_subscription_period_interval / 12;
                 update_post_meta($variation_id, '_subscription_period_interval', $child_years_interval);
                 update_post_meta($variation_id, '_subscription_period', 'year');
                 update_post_meta($variation_id, 'vindi_subscription_period_interval', $child_years_interval);
                 update_post_meta($variation_id, 'vindi_subscription_period', 'year');
-            } else if ($child_subscription_period_interval % 7 == 0 && $child_subscription_period == 'day') {
+            } else if ($this->is_weekly_plan($child_subscription_period_interval, $child_subscription_period)) {
                 $child_weeks_interval = (int) $child_subscription_period_interval / 7;
                 update_post_meta($variation_id, '_subscription_period_interval', $child_weeks_interval);
                 update_post_meta($variation_id, '_subscription_period', 'week');
@@ -319,6 +319,26 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 
 			return self::$instance;
 		}
+
+        /**
+         * Returns if it is an weekly periodicity
+         * @return bool
+         */
+        public function is_weekly_plan($period_interval, $subscription_period)
+        {
+            return $period_interval % 7 == 0
+                && $period_interval <= 28
+                && $subscription_period == 'day';
+        }
+
+        /**
+         * Returns if it is an annual periodicity
+         * @return bool
+         */
+        public function is_yearly_plan($period_interval, $subscription_period)
+        {
+            return $period_interval % 12 == 0 && $subscription_period == 'month';
+        }
 
 		/**
 		 * Include the dependents classes

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -134,7 +134,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                     array(&$this, 'variable_subscription_custom_fields')
                 , 10, 3);
 
-                add_action('woocommerce_process_product_meta',
+                add_action('save_post',
                     array(&$this, 'save_subscription_meta')
                 , 20);
 
@@ -304,7 +304,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             return in_array(
                 wc_clean($_POST['product-type']),
                 $allow_types
-            );
+            ) && 'product' !== wc_clean($_POST['post-type']);
         }
 
 		/**

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -215,7 +215,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             global $post;
 
             $plans         = $this->settings->api->get_plans();
-            $selected_plan = get_post_meta($variation->ID, 'vindi_subscription_plan', true);
+            $selected_plan = get_post_meta($variation->ID, 'vindi_variable_subscription_plan', true);
 
             $plans['names'] = array(__('-- Plano da Vindi Padrão  --', VINDI_IDENTIFIER)) + $plans['names'];
 
@@ -265,10 +265,10 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 
             if(preg_match('/variable-subscription/', $wc_product->get_type())) {
 
-                if (isset($_POST['vindi_subscription_plan'])){
+                if (isset($_POST['vindi_variable_subscription_plan'])){
 
-                    foreach ($_POST['vindi_subscription_plan'] as $child_key => $child_value) {
-                        $child_subscription_plan            = wc_clean($_POST['vindi_subscription_plan'][$child_key]);
+                    foreach ($_POST['vindi_variable_subscription_plan'] as $child_key => $child_value) {
+                        $child_subscription_plan            = wc_clean($_POST['vindi_variable_subscription_plan'][$child_key]);
                         $child_subscription_period_interval = wc_clean($_POST['variable_subscription_period_interval'][$child_key]);
                         $child_subscription_period          = wc_clean($_POST['variable_subscription_period'][$child_key]);
                         $child_subscription_length          = wc_clean($_POST['variable_subscription_length'][$child_key]);
@@ -287,7 +287,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                             update_post_meta($child_key, 'vindi_subscription_period', $child_subscription_period);
                         }
 
-                        update_post_meta($child_key, 'vindi_subscription_plan', $child_subscription_plan);
+                        update_post_meta($child_key, 'vindi_variable_subscription_plan', $child_subscription_plan);
                     }
 
                 }
@@ -301,25 +301,22 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                 return;
             }
 
-            /*$subscription_period_interval = get_post_meta($post_id, 'vindi_subscription_period_interval', true);
+            $subscription_period_interval = get_post_meta($post_id, 'vindi_subscription_period_interval', true);
             $subscription_period          = get_post_meta($post_id, 'vindi_subscription_period', true);
             $subscription_length          = get_post_meta($post_id, 'vindi_subscription_length', true);
-
             update_post_meta($post_id, '_subscription_length', $subscription_length);
             update_post_meta($post_id, '_subscription_period_interval', $subscription_period_interval);
             update_post_meta($post_id, '_subscription_period', $subscription_period);
 
-            $wc_product = wc_get_product($post_id);*/
+            if (isset($_POST['vindi_variable_subscription_plan'])){
 
-            if (isset($_POST['vindi_subscription_plan'])){
-
-                foreach ($_POST['vindi_subscription_plan'] as $child_key => $child_value) {
-                    $child_subscription_plan            = wc_clean($_POST['vindi_subscription_plan'][$child_key]);
+                foreach ($_POST['vindi_variable_subscription_plan'] as $child_key => $child_value) {
+                    $child_subscription_plan            = wc_clean($_POST['vindi_variable_subscription_plan'][$child_key]);
                     $child_subscription_period_interval = wc_clean($_POST['variable_subscription_period_interval'][$child_key]);
                     $child_subscription_period          = wc_clean($_POST['variable_subscription_period'][$child_key]);
                     $child_subscription_length          = wc_clean($_POST['variable_subscription_length'][$child_key]);
 
-                    update_post_meta($child_key, 'vindi_subscription_plan', $child_subscription_plan);
+                    update_post_meta($child_key, 'vindi_variable_subscription_plan', $child_subscription_plan);
                     update_post_meta($child_key, '_subscription_length', $child_subscription_length);
                     update_post_meta($child_key, '_subscription_period_interval', $child_subscription_period_interval);
                     update_post_meta($child_key, '_subscription_period', $child_subscription_period);
@@ -334,10 +331,10 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
          */
         public function save_subscription_variation_meta($variation_id, $i)
         {
-            $subscription_plan = wc_clean($_POST['vindi_subscription_plan'][$i]);
+            $subscription_plan = wc_clean($_POST['vindi_variable_subscription_plan'][$i]);
 
             if ( isset( $subscription_plan ) )
-                update_post_meta($variation_id, 'vindi_subscription_plan', $subscription_plan);
+                update_post_meta($variation_id, 'vindi_variable_subscription_plan', $subscription_plan);
         }
 
         private function is_product_type_from_post($allow_types)

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -146,13 +146,9 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                     array(&$this, 'save_subscription_meta')
                 , 20);
 
-                add_action('woocommerce_ajax_save_product_variations',
-                    array(&$this, 'save_ajax_subscription_meta')
-                , 10);
-
                 add_action('woocommerce_save_product_variation',
                     array(&$this, 'save_subscription_variation_meta')
-                , 10
+                , 20
                 , 2);
 
             }
@@ -262,68 +258,6 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             }
 
             update_post_meta($post_id, 'vindi_subscription_plan', $subscription_plan);
-
-            if(preg_match('/variable-subscription/', $wc_product->get_type())) {
-
-                if (isset($_POST['vindi_variable_subscription_plan'])){
-
-                    foreach ($_POST['vindi_variable_subscription_plan'] as $child_key => $child_value) {
-                        $child_subscription_plan            = wc_clean($_POST['vindi_variable_subscription_plan'][$child_key]);
-                        $child_subscription_period_interval = wc_clean($_POST['variable_subscription_period_interval'][$child_key]);
-                        $child_subscription_period          = wc_clean($_POST['variable_subscription_period'][$child_key]);
-                        $child_subscription_length          = wc_clean($_POST['variable_subscription_length'][$child_key]);
-
-                        update_post_meta($child_key, '_subscription_length', $child_subscription_length);
-                        if($child_subscription_period_interval % 12 == 0) {
-                            $child_years_interval = (int) $child_subscription_period_interval / 12;
-                            update_post_meta($child_key, '_subscription_period_interval', $child_years_interval);
-                            update_post_meta($child_key, '_subscription_period', 'year');
-                            update_post_meta($child_key, 'vindi_subscription_period_interval', $child_years_interval);
-                            update_post_meta($child_key, 'vindi_subscription_period', 'year');
-                        } else {
-                            update_post_meta($child_key, '_subscription_period_interval', $child_subscription_period_interval);
-                            update_post_meta($child_key, '_subscription_period', $child_subscription_period);
-                            update_post_meta($child_key, 'vindi_subscription_period_interval', $child_subscription_period_interval);
-                            update_post_meta($child_key, 'vindi_subscription_period', $child_subscription_period);
-                        }
-
-                        update_post_meta($child_key, 'vindi_variable_subscription_plan', $child_subscription_plan);
-                    }
-
-                }
-
-            }
-        }
-
-        public function save_ajax_subscription_meta($post_id)
-        {
-            if (false === $this->is_product_type_from_post(['variable-subscription'])) {
-                return;
-            }
-
-            $subscription_period_interval = get_post_meta($post_id, 'vindi_subscription_period_interval', true);
-            $subscription_period          = get_post_meta($post_id, 'vindi_subscription_period', true);
-            $subscription_length          = get_post_meta($post_id, 'vindi_subscription_length', true);
-            update_post_meta($post_id, '_subscription_length', $subscription_length);
-            update_post_meta($post_id, '_subscription_period_interval', $subscription_period_interval);
-            update_post_meta($post_id, '_subscription_period', $subscription_period);
-
-            if (isset($_POST['vindi_variable_subscription_plan'])){
-
-                foreach ($_POST['vindi_variable_subscription_plan'] as $child_key => $child_value) {
-                    $child_subscription_plan            = wc_clean($_POST['vindi_variable_subscription_plan'][$child_key]);
-                    $child_subscription_period_interval = wc_clean($_POST['variable_subscription_period_interval'][$child_key]);
-                    $child_subscription_period          = wc_clean($_POST['variable_subscription_period'][$child_key]);
-                    $child_subscription_length          = wc_clean($_POST['variable_subscription_length'][$child_key]);
-
-                    update_post_meta($child_key, 'vindi_variable_subscription_plan', $child_subscription_plan);
-                    update_post_meta($child_key, '_subscription_length', $child_subscription_length);
-                    update_post_meta($child_key, '_subscription_period_interval', $child_subscription_period_interval);
-                    update_post_meta($child_key, '_subscription_period', $child_subscription_period);
-                    update_post_meta($child_key, 'vindi_subscription_period_interval', $child_subscription_period_interval);
-                    update_post_meta($child_key, 'vindi_subscription_period', $child_subscription_period);
-                }
-            }
         }
 
         /**
@@ -331,10 +265,26 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
          */
         public function save_subscription_variation_meta($variation_id, $i)
         {
-            $subscription_plan = wc_clean($_POST['vindi_variable_subscription_plan'][$i]);
+            $child_subscription_plan            = wc_clean($_POST['vindi_variable_subscription_plan'][$i]);
+            $child_subscription_period_interval = wc_clean($_POST['variable_subscription_period_interval'][$i]);
+            $child_subscription_period          = wc_clean($_POST['variable_subscription_period'][$i]);
+            $child_subscription_length          = wc_clean($_POST['variable_subscription_length'][$i]);
 
-            if ( isset( $subscription_plan ) )
-                update_post_meta($variation_id, 'vindi_variable_subscription_plan', $subscription_plan);
+            update_post_meta($variation_id, '_subscription_length', $child_subscription_length);
+            if($child_subscription_period_interval % 12 == 0) {
+                $child_years_interval = (int) $child_subscription_period_interval / 12;
+                update_post_meta($variation_id, '_subscription_period_interval', $child_years_interval);
+                update_post_meta($variation_id, '_subscription_period', 'year');
+                update_post_meta($variation_id, 'vindi_subscription_period_interval', $child_years_interval);
+                update_post_meta($variation_id, 'vindi_subscription_period', 'year');
+            } else {
+                update_post_meta($variation_id, '_subscription_period_interval', $child_subscription_period_interval);
+                update_post_meta($variation_id, '_subscription_period', $child_subscription_period);
+                update_post_meta($variation_id, 'vindi_subscription_period_interval', $child_subscription_period_interval);
+                update_post_meta($variation_id, 'vindi_subscription_period', $child_subscription_period);
+            }
+
+            update_post_meta($variation_id, 'vindi_variable_subscription_plan', $child_subscription_plan);
         }
 
         private function is_product_type_from_post($allow_types)

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -283,12 +283,12 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                 update_post_meta($variation_id, '_subscription_period', 'year');
                 update_post_meta($variation_id, 'vindi_subscription_period_interval', $child_years_interval);
                 update_post_meta($variation_id, 'vindi_subscription_period', 'year');
-            } else if ($child_subscription_period_interval % 7 == 0 && $subscription_period == 'day') {
+            } else if ($child_subscription_period_interval % 7 == 0 && $child_subscription_period == 'day') {
                 $child_weeks_interval = (int) $child_subscription_period_interval / 7;
-                update_post_meta($child, '_subscription_period_interval', $child_weeks_interval);
-                update_post_meta($child, '_subscription_period', 'week');
-                update_post_meta($child_key, 'vindi_subscription_period_interval', $child_weeks_interval);
-                update_post_meta($child_key, 'vindi_subscription_period', 'week');
+                update_post_meta($variation_id, '_subscription_period_interval', $child_weeks_interval);
+                update_post_meta($variation_id, '_subscription_period', 'week');
+                update_post_meta($variation_id, 'vindi_subscription_period_interval', $child_weeks_interval);
+                update_post_meta($variation_id, 'vindi_subscription_period', 'week');
             } else {
                 update_post_meta($variation_id, '_subscription_period_interval', $child_subscription_period_interval);
                 update_post_meta($variation_id, '_subscription_period', $child_subscription_period);

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,13 +3,13 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.4.2
+ * Version: 5.5.0
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
- * Tested up to: 4.9.8
+ * Tested up to: 5.2.1
  * WC requires at least: 3.0.0
- * WC tested up to: 3.4.5
+ * WC tested up to: 3.6.4
  *
  * Text Domain: vindi-woocommerce-subscriptions
  * Domain Path: /languages/
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.4.2';
+        const VERSION = '5.5.0';
 
         /**
 		 * @var string

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -192,6 +192,8 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 
             $plans         = $this->settings->api->get_plans();
             $selected_plan = get_post_meta($post->ID, 'vindi_subscription_plan', true);
+            $wc_product = wc_get_product($post->ID);
+            $product_type = $wc_product->get_type();
 
             $plans['names'] = array(__('-- Selecione --', VINDI_IDENTIFIER)) + $plans['names'];
 
@@ -199,7 +201,8 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                 'admin-simple-product-subscription-fields.html.php',
                 compact(
                     'plans',
-                    'selected_plan'
+                    'selected_plan',
+                    'product_type'
                 )
             );
         }
@@ -214,7 +217,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             $plans         = $this->settings->api->get_plans();
             $selected_plan = get_post_meta($variation->ID, 'vindi_subscription_plan', true);
 
-            $plans['names'] = array(__('-- Selecione  --', VINDI_IDENTIFIER)) + $plans['names'];
+            $plans['names'] = array(__('-- Plano da Vindi Padrão  --', VINDI_IDENTIFIER)) + $plans['names'];
 
             $this->settings->get_template(
                 'admin-variable-product-subscription-fields.html.php',
@@ -289,9 +292,6 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 
                 }
 
-                delete_post_meta($post_id, 'vindi_subscription_plan');
-                delete_post_meta($post_id, 'vindi_subscription_period_interval');
-                delete_post_meta($post_id, 'vindi_subscription_period');
             }
         }
 

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -213,7 +213,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             $plans         = $this->settings->api->get_plans();
             $selected_plan = get_post_meta($variation->ID, 'vindi_variable_subscription_plan', true);
 
-            $plans['names'] = array(__('-- Plano da Vindi Padrão  --', VINDI_IDENTIFIER)) + $plans['names'];
+            $plans['names'] = array(__('-- Plano padrão da Vindi --', VINDI_IDENTIFIER)) + $plans['names'];
 
             $this->settings->get_template(
                 'admin-variable-product-subscription-fields.html.php',
@@ -277,7 +277,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
             $child_subscription_length          = wc_clean($_POST['variable_subscription_length'][$i]);
 
             update_post_meta($variation_id, '_subscription_length', $child_subscription_length);
-            if($this->is_yearly_plan($child_subscription_period_interval, $child_subscription_period)) {
+            if ($this->is_yearly_plan($child_subscription_period_interval, $child_subscription_period)) {
                 $child_years_interval = (int) $child_subscription_period_interval / 12;
                 update_post_meta($variation_id, '_subscription_period_interval', $child_years_interval);
                 update_post_meta($variation_id, '_subscription_period', 'year');


### PR DESCRIPTION
## Motivação
Atualmente as assinaturas variáveis não possuem opção para seleção de `Plano Vindi`. Sendo assim, é necessário criar vários produtos semelhantes para simular a diversidade de planos disponíveis.
## Solução proposta
- Para facilitar na criação de produtos variáveis, foi adicionado o campo "Plano da Vindi" em cada variação. Assim, não é necessário criar 4 **produtos idênticos** com **planos diferentes** (mensal, trimestral, semestral, anual, etc).
**Ex:**
> Possuo um produto com 28 variações, e em cada variação eu defino um dos 4 planos que criei no painel da Vindi.
- Plano da Vindi `default` pra quando o usuário não especificar um plano em alguma variação.
- Inserir o suporte a periodicidades de 1-60 dias/meses/anosno plugin.
- Inserir compatibilidade com planos semanais