### PR TITLE
Oculta metadados (type, vindi_id e price) no frontend 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.5.1 - 04/06/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.1)
+
+### Ajustado
+- Oculta metadados (type, vindi_id e price) do frontend
+
+
 ## [5.5.0 - 04/06/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.0)
 
 ### Adicionado

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -158,13 +158,6 @@ class Vindi_Settings extends WC_Settings_API
                 'description'      => __('Fretes e Taxas serão cobrados somente no primeiro ciclo de uma assinatura', VINDI_IDENTIFIER),
                 'default'          => 'no',
             ),
-            'hide_item_meta_data'  => array(
-                'title'            => __('Metadados no Frontend', VINDI_IDENTIFIER),
-                'type'             => 'checkbox',
-                'label'      => __('Ocultar metadados no Frontend', VINDI_IDENTIFIER),
-                'description'      => __('Ocultar metadados (type, vindi_id e price) na lista de itens do frontend.', VINDI_IDENTIFIER),
-                'default'          => 'no',
-            ),
 			'testing'              => array(
 				'title'            => __('Testes', 'vindi-woocommerce'),
 				'type'             => 'title',
@@ -253,15 +246,6 @@ class Vindi_Settings extends WC_Settings_API
     public function get_shipping_and_tax_config()
     {
         return 'yes' === $this->settings['shipping_and_tax_config'];
-    }
-
-    /**
-     * Get Vindi Synchronism status
-     * @return string
-     **/
-    public function get_hide_item_meta_data_status()
-    {
-        return 'yes' === $this->settings['hide_item_meta_data'];
     }
 
     /**

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -158,6 +158,13 @@ class Vindi_Settings extends WC_Settings_API
                 'description'      => __('Fretes e Taxas serão cobrados somente no primeiro ciclo de uma assinatura', VINDI_IDENTIFIER),
                 'default'          => 'no',
             ),
+            'hide_item_meta_data'  => array(
+                'title'            => __('Metadados no Frontend', VINDI_IDENTIFIER),
+                'type'             => 'checkbox',
+                'label'      => __('Ocultar metadados no Frontend', VINDI_IDENTIFIER),
+                'description'      => __('Ocultar metadados (type, vindi_id e price) na lista de itens do frontend.', VINDI_IDENTIFIER),
+                'default'          => 'no',
+            ),
 			'testing'              => array(
 				'title'            => __('Testes', 'vindi-woocommerce'),
 				'type'             => 'title',
@@ -246,6 +253,15 @@ class Vindi_Settings extends WC_Settings_API
     public function get_shipping_and_tax_config()
     {
         return 'yes' === $this->settings['shipping_and_tax_config'];
+    }
+
+    /**
+     * Get Vindi Synchronism status
+     * @return string
+     **/
+    public function get_hide_item_meta_data_status()
+    {
+        return 'yes' === $this->settings['hide_item_meta_data'];
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 5.2.1
 WC requires at least: 3.0.0
 WC tested up to: 3.6.4
-Stable Tag: 5.5.0
+Stable Tag: 5.5.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,9 @@ Caso necessite de informações sobre a plataforma ou API por favor siga atravé
 - [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)[Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br)
 
 == Changelog ==
+
+= 5.5.1 - 11/06/2019 =
+- Oculta metadados (type, vindi_id e price) do frontend
 
 = 5.5.0 - 04/06/2019 =
 - Adiciona plano da Vindi para assinaturas do tipo variável

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -146,8 +146,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                     array(&$this, 'save_subscription_variation_meta')
                 , 20, 2);
             } else {
-                if ($this->settings->get_hide_item_meta_data_status())
-                    add_filter( 'woocommerce_order_item_get_formatted_meta_data', array( &$this, 'hide_item_meta_data'), 10, 1 );
+                add_filter( 'woocommerce_order_item_get_formatted_meta_data', array( &$this, 'hide_item_meta_data'), 10, 1 );
             }
 		}
 

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -145,6 +145,9 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                 add_action('woocommerce_save_product_variation',
                     array(&$this, 'save_subscription_variation_meta')
                 , 20, 2);
+            } else {
+                if ($this->settings->get_hide_item_meta_data_status())
+                    add_filter( 'woocommerce_order_item_get_formatted_meta_data', array( &$this, 'hide_item_meta_data'), 10, 1 );
             }
 		}
 
@@ -468,6 +471,23 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                 return;
 
             curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+        }
+
+        /**
+         * @param array $formatted_meta
+         **/
+        function hide_item_meta_data($formatted_meta){
+            $temp_metas = [];
+            foreach($formatted_meta as $key => $meta) {
+                if ( isset( $meta->key ) && ! in_array( $meta->key, [
+                        'type',
+                        'vindi_id',
+                        'price'
+                    ] ) ) {
+                    $temp_metas[ $key ] = $meta;
+                }
+            }
+            return $temp_metas;
         }
 	}
 }

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -146,7 +146,8 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                     array(&$this, 'save_subscription_variation_meta')
                 , 20, 2);
             } else {
-                add_filter( 'woocommerce_order_item_get_formatted_meta_data', array( &$this, 'hide_item_meta_data'), 10, 1 );
+                add_filter( 'woocommerce_order_item_get_formatted_meta_data',
+                    array( &$this, 'hide_item_meta_data'), 10, 1 );
             }
 		}
 

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.5.0
+ * Version: 5.5.1
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.5.0';
+        const VERSION = '5.5.1';
 
         /**
 		 * @var string


### PR DESCRIPTION
Opção para ocultar metadados **type**, **vindi_id** e **price** do frontend, segue imagem para melhor compreensão:

![meta_dados](https://user-images.githubusercontent.com/16960561/58980412-a25f8280-87a6-11e9-998c-58195dbef3ef.png)