### PR TITLE
Aceitar Pagamentos Antecipados de Renovação

### DIFF
--- a/includes/class-vindi-api.php
+++ b/includes/class-vindi-api.php
@@ -244,6 +244,22 @@ class Vindi_API
         return false;
     }
 
+    /**
+     * @param int   $subscription_id
+     *
+     * @return array|bool|mixed
+     */
+    public function renew_subscription($subscription_id)
+    {
+        if ($renew_response = $this->request('subscriptions/' . $subscription_id . '/renew', 'POST')){
+            $period_id = $renew_response['period']['id'];
+            if ($response = $this->request('periods/' . $period_id . '/bill', 'POST'))
+                return $response;
+        }
+
+        return false;
+    }
+
 
 	/**
 	 * @param int   $subscription_id

--- a/includes/class-vindi-settings.php
+++ b/includes/class-vindi-settings.php
@@ -376,4 +376,15 @@ class Vindi_Settings extends WC_Settings_API
 
         return $api_key;
     }
+
+    /**
+     * @param WC_Subscription $wc_subscription
+     **/
+    public function get_vindi_subscription_id($wc_subscription)
+    {
+        $subscription_id = method_exists($wc_subscription, 'get_id')
+        ? $wc_subscription->get_id()
+        : $wc_subscription->id;
+        return end(get_post_meta($subscription_id, 'vindi_wc_subscription_id'));
+    }
 }

--- a/includes/class-vindi-subscription-status-handler.php
+++ b/includes/class-vindi-subscription-status-handler.php
@@ -50,7 +50,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function suspend_status($wc_subscription)
     {
-        $subscription_id = $this->get_vindi_subscription_id($wc_subscription);
+        $subscription_id = $this->container->get_vindi_subscription_id($wc_subscription);
         if ($this->container->get_synchronism_status()) {
             $this->container->api->suspend_subscription($subscription_id);
         }
@@ -61,7 +61,7 @@ class Vindi_Subscription_Status_Handler
      **/
     public function cancelled_status($wc_subscription)
     {
-        $subscription_id = $this->get_vindi_subscription_id($wc_subscription);
+        $subscription_id = $this->container->get_vindi_subscription_id($wc_subscription);
         if ($this->container->api->is_subscription_active($subscription_id)) {
             $this->container->api->suspend_subscription($subscription_id, true); 
         }
@@ -74,21 +74,11 @@ class Vindi_Subscription_Status_Handler
     {
         if ('pending' == $old_status)
             return;
-        $subscription_id = $this->get_vindi_subscription_id($wc_subscription);
+        $subscription_id = $this->container->get_vindi_subscription_id($wc_subscription);
         if ($this->container->get_synchronism_status()
             && !$this->container->api->is_subscription_active($subscription_id)) {
             $this->container->api->activate_subscription($subscription_id);
         }
     }
 
-    /**
-     * @param WC_Subscription $wc_subscription
-     **/
-    public function get_vindi_subscription_id($wc_subscription)
-    {
-        $subscription_id = method_exists($wc_subscription, 'get_id')
-        ? $wc_subscription->get_id()
-        : $wc_subscription->id;
-        return end(get_post_meta($subscription_id, 'vindi_wc_subscription_id'));
-    }
 }

--- a/includes/class-vindi-wcs-early-renewal.php
+++ b/includes/class-vindi-wcs-early-renewal.php
@@ -1,0 +1,88 @@
+<?php
+if (!defined('ABSPATH')) {
+	die('not allowed');
+}
+
+class Vindi_WCS_Early_Renewal
+{
+	/**
+     * Vindi Gateway.
+     * @var Vindi_Settings
+     */
+    protected $container;
+
+	/**
+     * @param Vindi_Settings     $container
+     */
+	public function __construct(Vindi_Settings $container) {
+		$this->container = $container;
+		add_filter( 'wcs_view_subscription_actions', array( 
+			&$this, 
+			'replace_early_renewal_url'
+		), 100, 2 );
+		add_action('template_redirect', array(
+			&$this,
+			'early_renewal_action'
+		), 100);
+	}
+
+	function replace_early_renewal_url($actions, $subscription){
+			foreach ( $actions as $action_key => $action ) {
+				if ($action_key == 'subscription_renewal_early'){
+
+					if (!empty($subscription->get_meta('vindi_wc_subscription_id'))) {
+
+						if (isset($_GET['vindi_subscription_renewal'])){
+							unset($actions[$action_key]);
+						} else {
+							$subscription_id = is_a( $subscription, 'WC_Subscription' ) ? $subscription->get_id() : absint( $subscription );
+
+							$url = add_query_arg( array(
+								'vindi_subscription_renewal_early' => $subscription_id,
+							), get_permalink( wc_get_page_id( 'myaccount' ) ) );
+
+							$actions[$action_key]['url'] = $url;
+						}
+					}
+					break;
+				}
+			}
+			return $actions;
+		}
+
+	function early_renewal_action() {
+		if ( ! isset( $_GET['vindi_subscription_renewal_early'] ) ) {
+			return;
+		}
+
+		$wc_subscription = wcs_get_subscription( absint( $_GET['vindi_subscription_renewal_early'] ) );
+		$redirect_to	 = $url = add_query_arg( array(
+							'vindi_subscription_renewal' => 'true',
+						), $wc_subscription->get_view_order_url() );
+
+		if ( empty( $wc_subscription ) ) {
+
+			wc_add_notice( __( 'That subscription does not exist. Has it been deleted?', 'woocommerce-subscriptions' ), 'error' );
+
+		} elseif ( ! current_user_can( 'subscribe_again', $wc_subscription->get_id() ) ) {
+
+			wc_add_notice( __( "That doesn't appear to be one of your subscriptions.", 'woocommerce-subscriptions' ), 'error' );
+
+		} elseif ( ! wcs_can_user_renew_early( $wc_subscription ) ) {
+
+			wc_add_notice( __( 'You can not renew this subscription early. Please contact us if you need assistance.', 'woocommerce-subscriptions' ), 'error' );
+
+		} else {
+
+			$subscription_id = $this->container->get_vindi_subscription_id($wc_subscription);
+
+			if ($this->container->api->renew_subscription($subscription_id)){
+				wc_add_notice( __('Renovação de assinatura antecipada! Em alguns minutos você receberá um email com mais informações.', VINDI_IDENTIFIER), 'success' );
+			}
+
+		}
+
+		wp_safe_redirect( $redirect_to );
+		exit;
+	}
+}

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -76,6 +76,11 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 		 */
 		private $subscription_status_handler = null;
 
+        /**
+         * @var Vindi_WCS_Early_Renewal
+         */
+        private $wcs_early_renewal = null;
+
 		public function __construct()
 		{
 			$this->includes(array(
@@ -89,11 +94,13 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
     			'class-vindi-webhook-handler.php',
     			'class-vindi-subscription-status-handler.php',
                 'class-vindi-wcs-disable-renewal.php',
+                'class-vindi-wcs-early-renewal.php'
             ));
 
 			$this->settings                    = new Vindi_Settings();
             $this->webhook_handler             = new Vindi_Webhook_Handler($this->settings);
             $this->subscription_status_handler = new Vindi_Subscription_Status_Handler($this->settings);
+            $this->wcs_early_renewal           = new Vindi_WCS_Early_Renewal($this->settings);
 
             add_action('http_api_curl', [ &$this, 'add_support_to_tlsv1_2' ]);
 


### PR DESCRIPTION
Permite antecipar a renovação de uma assinatura através da área do cliente (Minha Conta) ao ativar a configuração em WooCommerce > Assinaturas > Aceitar Renovações Manuais.

Mais informações: #121 