### PR TITLE
Corrige exibição de datas no plugin

### DIFF
--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -387,18 +387,18 @@ class Vindi_Webhook_Handler
                 return false;
             }
 
-			// format next payment date
-        $next_payment = date_formatter($next_billing_at);
+            // format next payment date
+            $next_payment = date_formatter($next_billing_at);
 
             // format end date
-        $end_date = date_formatter($end_at);
+            $end_date = date_formatter($end_at);
 
-			// find our wc_subscription
-		$subscription = $this->find_subscription_by_id($data->bill->subscription->code);
+            // find our wc_subscription
+		    $subscription = $this->find_subscription_by_id($data->bill->subscription->code);
 
-			// update the subscription dates
-        $subscription->update_dates(array('next_payment' => $next_payment));
-        $subscription->update_dates(array('end_date'     => $end_date));
+            // update the subscription dates
+            $subscription->update_dates(array('next_payment' => $next_payment));
+            $subscription->update_dates(array('end_date'     => $end_date));
         }
     }
 

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -377,11 +377,11 @@ class Vindi_Webhook_Handler
 		// we need this step because the actual next billing date does not come from the /bill webhook
         $vindi_subscription = $this->container->api->get_subscription($data->bill->subscription->id);
 
-        $next_billing_at = $vindi_subscription['next_billing_at'];
+        if ($vindi_subscription && isset($vindi_subscription['next_billing_at'])) {
 
-        $end_at = $vindi_subscription['end_at'];
+            $next_billing_at = $vindi_subscription['next_billing_at'];
 
-        if ($vindi_subscription && isset($next_billing_at)) {
+            $end_at = $vindi_subscription['end_at'];
 
             if ($next_billing_at > $end_at) {
                 return false;
@@ -404,8 +404,6 @@ class Vindi_Webhook_Handler
 
     private function format_date($date)
     {
-        $date = date('Y-m-d H:i:s', strtotime($date));
-
-        return $date;
+        return date('Y-m-d H:i:s', strtotime($date));
     }
 }

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -375,19 +375,23 @@ class Vindi_Webhook_Handler
 
 		// let's find the subscription in the API
 		// we need this step because the actual next billing date does not come from the /bill webhook
-		$vindi_subscription = $this->container->api->get_subscription($data->bill->subscription->id);
+        $vindi_subscription = $this->container->api->get_subscription($data->bill->subscription->id);
 
-		if ($vindi_subscription && isset($vindi_subscription['next_billing_at'])) {
-            
-            if ($vindi_subscription['next_billing_at'] > $vindi_subscription['end_at']) {
+        $next_billing_at = $vindi_subscription['next_billing_at'];
+
+        $end_at = $vindi_subscription['end_at'];
+
+		if ($vindi_subscription && isset($next_billing_at)) {
+
+            if ($next_billing_at > $end_at) {
             return false;
             }
 
 			// format next payment date
-            $next_payment = date('Y-m-d H:i:s', strtotime($vindi_subscription['next_billing_at']));
-            
+            $next_payment = date_formatter($next_billing_at);
+
             // format end date
-            $end_date = date('Y-m-d H:i:s', strtotime($vindi_subscription['end_at']));
+            $end_date = date_formatter($end_at);
 
 			// find our wc_subscription
 			$subscription = $this->find_subscription_by_id($data->bill->subscription->code);
@@ -396,5 +400,11 @@ class Vindi_Webhook_Handler
             $subscription->update_dates(array('next_payment' => $next_payment));
             $subscription->update_dates(array('end_date'     => $end_date));
         }
+    }
+
+	private function date_formatter($date) {
+        $date = date('Y-m-d H:i:s', strtotime($date));
+
+        return $date;
     }
 }

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -388,10 +388,10 @@ class Vindi_Webhook_Handler
             }
 
             // format next payment date
-            $next_payment = date_formatter($next_billing_at);
+            $next_payment = format_date($next_billing_at);
 
             // format end date
-            $end_date = date_formatter($end_at);
+            $end_date = format_date($end_at);
 
             // find our wc_subscription
 		    $subscription = $this->find_subscription_by_id($data->bill->subscription->code);
@@ -402,7 +402,7 @@ class Vindi_Webhook_Handler
         }
     }
 
-    private function date_formatter($date)
+    private function format_date($date)
     {
         $date = date('Y-m-d H:i:s', strtotime($date));
 

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -394,7 +394,7 @@ class Vindi_Webhook_Handler
             $end_date = format_date($end_at);
 
             // find our wc_subscription
-		    $subscription = $this->find_subscription_by_id($data->bill->subscription->code);
+		      $subscription = $this->find_subscription_by_id($data->bill->subscription->code);
 
             // update the subscription dates
             $subscription->update_dates(array('next_payment' => $next_payment));

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -371,8 +371,8 @@ class Vindi_Webhook_Handler
 	 *
 	 * @param $data object
 	 **/
-	private function update_next_payment($data) {
-
+    private function update_next_payment($data)
+    {
 		// let's find the subscription in the API
 		// we need this step because the actual next billing date does not come from the /bill webhook
         $vindi_subscription = $this->container->api->get_subscription($data->bill->subscription->id);
@@ -381,28 +381,29 @@ class Vindi_Webhook_Handler
 
         $end_at = $vindi_subscription['end_at'];
 
-		if ($vindi_subscription && isset($next_billing_at)) {
+        if ($vindi_subscription && isset($next_billing_at)) {
 
             if ($next_billing_at > $end_at) {
-            return false;
+                return false;
             }
 
 			// format next payment date
-            $next_payment = date_formatter($next_billing_at);
+        $next_payment = date_formatter($next_billing_at);
 
             // format end date
-            $end_date = date_formatter($end_at);
+        $end_date = date_formatter($end_at);
 
 			// find our wc_subscription
-			$subscription = $this->find_subscription_by_id($data->bill->subscription->code);
+		$subscription = $this->find_subscription_by_id($data->bill->subscription->code);
 
 			// update the subscription dates
-            $subscription->update_dates(array('next_payment' => $next_payment));
-            $subscription->update_dates(array('end_date'     => $end_date));
+        $subscription->update_dates(array('next_payment' => $next_payment));
+        $subscription->update_dates(array('end_date'     => $end_date));
         }
     }
 
-	private function date_formatter($date) {
+    private function date_formatter($date)
+    {
         $date = date('Y-m-d H:i:s', strtotime($date));
 
         return $date;

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -378,15 +378,23 @@ class Vindi_Webhook_Handler
 		$vindi_subscription = $this->container->api->get_subscription($data->bill->subscription->id);
 
 		if ($vindi_subscription && isset($vindi_subscription['next_billing_at'])) {
+            
+            if ($vindi_subscription['next_billing_at'] > $vindi_subscription['end_at']) {
+            return false;
+            }
 
 			// format next payment date
-			$next_payment = date('Y-m-d H:i:s', strtotime($vindi_subscription['next_billing_at']));
+            $next_payment = date('Y-m-d H:i:s', strtotime($vindi_subscription['next_billing_at']));
+            
+            // format end date
+            $end_date = date('Y-m-d H:i:s', strtotime($vindi_subscription['end_at']));
 
 			// find our wc_subscription
 			$subscription = $this->find_subscription_by_id($data->bill->subscription->code);
 
-			// update the date to show the user when will be his next payment
-			$subscription->update_dates(array('next_payment' => $next_payment));
-		}
-	}
+			// update the subscription dates
+            $subscription->update_dates(array('next_payment' => $next_payment));
+            $subscription->update_dates(array('end_date'     => $end_date));
+        }
+    }
 }

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -383,6 +383,11 @@ class Vindi_Webhook_Handler
 
             $end_at = $vindi_subscription['end_at'];
 
+            // na api, quando o plano é de cobrança única,
+            // o next_billing_at é 1 segundo maior que o end_at
+            // quando isso acontecer, o next_payment do wc deve ser null
+            // (a issue #134 tem mais informações do problema)
+
             if ($next_billing_at > $end_at) {
                 return false;
             }


### PR DESCRIPTION
Issue: closes #134 

## Motivação
Na issue #134, foi relatado um problema com a exibição das datas de término e de próximo pagamento da assinatura.

## Solução Proposta
Estou formatando a data de fim da assinatura e passando uma condição para impedir que o "next_billing_at" seja exibido nesse tipo de situação (plano de cobrança única).