### PR TITLE
Corrige exibição de planos apenas para produtos de assinatura

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Notas das versões
 
+## [5.5.3 - 22/01/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.3)
+
+### Corrigido
+- Corrige exibição de plano apenas para produtos de assinatura
+
 ## [5.5.2 - 09/01/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.2)
 
 ### Corrigido

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 5.2.1
 WC requires at least: 3.0.0
 WC tested up to: 3.6.4
-Stable Tag: 5.5.2
+Stable Tag: 5.5.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -26,6 +26,9 @@ Para verificar os requisitos e efetuar a instalação do plugin, [siga as instru
 Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através da nossa [central de atendimento](https://atendimento.vindi.com.br/hc/pt-br).
 
 == Changelog ==
+
+= 5.5.3 - 22/01/2020 =
+- Corrige exibição de plano apenas para produtos de assinatura
 
 = 5.5.2 - 09/01/2020 =
 - Corrige exibição de datas no plugin

--- a/templates/admin-simple-product-subscription-fields.html.php
+++ b/templates/admin-simple-product-subscription-fields.html.php
@@ -22,22 +22,35 @@
     if (preg_match('/variable-subscription/', $product_type)) {
         $label = __('Plano padrão da Vindi', VINDI_IDENTIFIER);
         $description = __('Selecione o plano padrão da Vindi que deseja relacionar a esse produto caso não especifique na variação', VINDI_IDENTIFIER);
-    } else {
+
+        woocommerce_wp_select(array(
+            'id'                 => 'vindi_subscription_plan',
+            'label'              => $label,
+            'options'            => $plans['names'],
+            'description'        => $description,
+            'desc_tip'           => true,
+            'value'              => $selected_plan,
+            'custom_attributes'  => array(
+                'data-plan-info' => json_encode($plans['infos'])
+            )
+        ));
+    } else if (preg_match('/simple-subscription/', $product_type))  {
         $label = __('Plano da Vindi', VINDI_IDENTIFIER);
         $description = __('Selecione o plano da Vindi que deseja relacionar a esse produto', VINDI_IDENTIFIER);
+
+        woocommerce_wp_select(array(
+            'id'                 => 'vindi_subscription_plan',
+            'label'              => $label,
+            'options'            => $plans['names'],
+            'description'        => $description,
+            'desc_tip'           => true,
+            'value'              => $selected_plan,
+            'custom_attributes'  => array(
+                'data-plan-info' => json_encode($plans['infos'])
+            )
+        ));
     }
 
-    woocommerce_wp_select(array(
-        'id'                 => 'vindi_subscription_plan',
-        'label'              => $label,
-        'options'            => $plans['names'],
-        'description'        => $description,
-        'desc_tip'           => true,
-        'value'              => $selected_plan,
-        'custom_attributes'  => array(
-            'data-plan-info' => json_encode($plans['infos'])
-        )
-    ));
 ?>
 </div>
 <div class="show_if_subscription clear"></div>

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.5.2
+ * Version: 5.5.3
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.5.2';
+        const VERSION = '5.5.3';
 
         /**
 		 * @var string


### PR DESCRIPTION
Issue: closes #138 

## Motivação
Como reportado na issue #138, os planos da Vindi estão aparecendo para produtos simples e outras variações de produtos. Os planos devem apenas aparecer para produtos de assinatura (simple subscription ou variable subscription).

## Solução Proposta
Estou adicionando a label da seleção dos planos para a condição do tipo de produto de assinatura.
