### PR TITLE
Remove exibição dos campos para assinatura Vindi quando o WCS está desabilitado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Notas das versões
 
+## [5.5.3 - 30/01/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.3)
+
+### Corrigido
+- Remove exibição dos campos para assinatura Vindi quando o Woocommerce Subscriptions não está habilitado
+
+
 ## [5.5.2 - 09/01/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.2)
 
 ### Corrigido
 - Corrige exibição de datas no plugin
+
 
 ## [5.5.1 - 04/06/2019](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.1)
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 5.2.1
 WC requires at least: 3.0.0
 WC tested up to: 3.6.4
-Stable Tag: 5.5.2
+Stable Tag: 5.5.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -26,6 +26,9 @@ Para verificar os requisitos e efetuar a instalação do plugin, [siga as instru
 Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através da nossa [central de atendimento](https://atendimento.vindi.com.br/hc/pt-br).
 
 == Changelog ==
+
+= 5.5.3 - 30/01/2020 =
+- Remove exibição dos campos para assinatura Vindi quando o Woocommerce Subscriptions não está habilitado
 
 = 5.5.2 - 09/01/2020 =
 - Corrige exibição de datas no plugin

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -126,13 +126,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                     &$this, 'add_admin_scripts'
                 ));
 
-                add_action('woocommerce_product_options_general_product_data',
-                    array(&$this, 'simple_subscription_custom_fields')
-                );
-
-                add_action('woocommerce_product_after_variable_attributes',
-                    array(&$this, 'variable_subscription_custom_fields')
-                , 10, 3);
+                $this->set_vindi_subscription_fields();
 
                 add_action('woocommerce_process_product_meta',
                     array(&$this, 'save_subscription_meta')
@@ -150,6 +144,24 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
                     array( &$this, 'hide_item_meta_data'), 10, 1 );
             }
 		}
+
+        /**
+         * Enable/Disable Vindi subscription fields according to WCS
+         */
+        public function set_vindi_subscription_fields()
+        {
+            if ($this->settings->dependency->wc_subscriptions_are_activated()) {
+                add_action('woocommerce_product_options_general_product_data',
+                    array(&$this, 'simple_subscription_custom_fields'));
+                add_action('woocommerce_product_after_variable_attributes',
+                    array(&$this, 'variable_subscription_custom_fields'), 10, 3); 
+            } else {
+                remove_action('woocommerce_product_options_general_product_data',
+                    array(&$this, 'simple_subscription_custom_fields'));
+                remove_action('woocommerce_product_after_variable_attributes',
+                    array(&$this, 'variable_subscription_custom_fields'), 10, 3);  
+            }
+        } 
 
         /**
          * Set supported intervals number for subscription plans

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.5.2
+ * Version: 5.5.3
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.5.2';
+        const VERSION = '5.5.3';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
Está sendo exibido um **erro fatal** quando o plugin **WooCommerce Subscriptions** está desinstalado ou inativo.
Esse erro foi reportado durante uma apresentação comercial e precisa ser resolvido o quanto antes possível :warning: 

## Solução Proposta
Adicionar o mecanismo para remover os campos para assinaturas da Vindi quando o plugin responsável por gerenciar assinaturas (WooCommerce Subscriptions) estiver **desinstalado** ou **inativo**.

Por se tratar de um **erro crítico**, iremos validar a inclusão de novos testes tendo em vista que estamos trabalhando na implantação de um **novo plugin**.
