### PR TITLE
Atualiza verificação de dependência WCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.5.4 - 31/01/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.4)
+
+### Ajustado
+- Ajusta verificação de status do plugin WooCommerce Subscriptions para garantir compatibilidade com novas versões
+
+
 ## [5.5.3 - 30/01/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.3)
 
 ### Corrigido

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -141,13 +141,7 @@ class Vindi_Dependencies
             ],
         ];
 
-        if(self::plugin_are_active($wc_subscriptions)){
-            if(self::verify_version_of_plugin($wc_subscriptions)){
-                return true;
-            }
-        }
-
-        return false;
+        return self::plugin_are_active($wc_subscriptions) || class_exists('WC_Subscriptions')
     }
 
     /**

--- a/includes/class-vindi-dependencies.php
+++ b/includes/class-vindi-dependencies.php
@@ -141,7 +141,7 @@ class Vindi_Dependencies
             ],
         ];
 
-        return self::plugin_are_active($wc_subscriptions) || class_exists('WC_Subscriptions')
+        return self::plugin_are_active($wc_subscriptions) || class_exists('WC_Subscriptions');
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: erico.pedroso, wnarde, lyoncesar, laertejr
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions, vindi-woocommerce
 Requires at least: 4.4
-Tested up to: 5.2.1
+Tested up to: 5.3.2
 WC requires at least: 3.0.0
-WC tested up to: 3.6.4
-Stable Tag: 5.5.3
+WC tested up to: 3.8.1
+Stable Tag: 5.5.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -26,6 +26,9 @@ Para verificar os requisitos e efetuar a instalação do plugin, [siga as instru
 Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através da nossa [central de atendimento](https://atendimento.vindi.com.br/hc/pt-br).
 
 == Changelog ==
+
+= 5.5.4 - 31/01/2020 =
+- Ajusta verificação de status do plugin WooCommerce Subscriptions para garantir compatibilidade com novas versões
 
 = 5.5.3 - 30/01/2020 =
 - Remove exibição dos campos para assinatura Vindi quando o Woocommerce Subscriptions não está habilitado

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,18 +3,18 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.5.3
+ * Version: 5.5.4
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
- * Tested up to: 5.2.1
+ * Tested up to: 5.3.2
  * WC requires at least: 3.0.0
- * WC tested up to: 3.6.4
+ * WC tested up to: 3.8.1
  *
  * Text Domain: vindi-woocommerce-subscriptions
  * Domain Path: /languages/
  *
- * Copyright: © 2014-2018 Vindi Tecnologia e Marketing LTDA
+ * Copyright: © 2014-2020 Vindi Tecnologia e Marketing LTDA
  * License: GPLv3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.5.3';
+        const VERSION = '5.5.4';
 
         /**
 		 * @var string


### PR DESCRIPTION
## Motivação
A verificação do status do plugin **WooCommerce Subscritpions** não cobre todos os casos.
Algumas versões não estão sendo verificadas, fazendo com que as funcionalidades de assinaturas não sejam exibidas.
Isso acontece pois a validação atual é realizado por pastas, e o plugin pode estar em alguma pasta customizada.

## Solução Proposta
Ajustar a validação _legado_ do **Wordpress** para status de plugins, adicionando a verificação da classe.
A classe do **WooCommerce Subscriptions** deve estar presente para que as funcionalidades de assinaturas funcione.
