### PR TITLE
Botão para visualização/download do boleto na área de pedidos e assinaturas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [5.5.5 - 16/03/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.5)
+
+### Adicionado
+- Adiciona botão para visualização/download do boleto na área de pedidos e assinaturas (por [@cristian-rossi](https://github.com/cristian-rossi): [#142](https://github.com/vindi/vindi-woocommerce-subscriptions/pull/142))
+
+
 ## [5.5.4 - 31/01/2020](https://github.com/vindi/vindi-woocommerce-subscriptions/releases/tag/5.5.4)
 
 ### Ajustado

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -98,7 +98,7 @@ class Vindi_Webhook_Handler
         add_post_meta($order->id, 'vindi_wc_cycle', $renew_infos['cycle']);
         add_post_meta($order->id, 'vindi_wc_bill_id', $renew_infos['bill_id']);
         add_post_meta($order->id, 'vindi_wc_subscription_id', $renew_infos['vindi_subscription_id']);
-        if(!empty($renew_infos['print_url'])) {
+        if (!empty($renew_infos['print_url'])) {
             add_post_meta( $order->id, 'vindi_wc_invoice_download_url', $renew_infos['print_url'] );
         }
 

--- a/includes/class-vindi-webhook-handler.php
+++ b/includes/class-vindi-webhook-handler.php
@@ -98,6 +98,9 @@ class Vindi_Webhook_Handler
         add_post_meta($order->id, 'vindi_wc_cycle', $renew_infos['cycle']);
         add_post_meta($order->id, 'vindi_wc_bill_id', $renew_infos['bill_id']);
         add_post_meta($order->id, 'vindi_wc_subscription_id', $renew_infos['vindi_subscription_id']);
+        if(!empty($renew_infos['print_url'])) {
+            add_post_meta( $order->id, 'vindi_wc_invoice_download_url', $renew_infos['print_url'] );
+        }
 
         $this->container->logger->log('Novo Período criado: Pedido #'.$order->id);
 
@@ -119,7 +122,8 @@ class Vindi_Webhook_Handler
             'wc_subscription_id'     => $data->bill->subscription->code,
             'vindi_subscription_id'  => $data->bill->subscription->id,
             'cycle'                  => $data->bill->period->cycle,
-            'bill_id'                => $data->bill->id
+            'bill_id'                => $data->bill->id,
+            'print_url'              => $data->bill->charges[0]->print_url
         ];
 
         if (!$this->subscription_has_order_in_cycle($renew_infos['vindi_subscription_id']

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.4
 Tested up to: 5.3.2
 WC requires at least: 3.0.0
 WC tested up to: 3.8.1
-Stable Tag: 5.5.4
+Stable Tag: 5.5.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -26,6 +26,8 @@ Para verificar os requisitos e efetuar a instalação do plugin, [siga as instru
 Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através da nossa [central de atendimento](https://atendimento.vindi.com.br/hc/pt-br).
 
 == Changelog ==
+= 5.5.5 - 16/03/2020 =
+- Adiciona botão para visualização/download do boleto na área de pedidos e assinaturas (por [@cristian-rossi](https://github.com/cristian-rossi): [#142](https://github.com/vindi/vindi-woocommerce-subscriptions/pull/142))
 
 = 5.5.4 - 31/01/2020 =
 - Ajusta verificação de status do plugin WooCommerce Subscriptions para garantir compatibilidade com novas versões

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vindi Woocommerce
  * Plugin URI:
  * Description: Adiciona o gateway de pagamentos da Vindi para o WooCommerce.
- * Version: 5.5.4
+ * Version: 5.5.5
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
  * Requires at least: 4.4
@@ -39,7 +39,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 	    /**
 		 * @var string
 		 */
-        const VERSION = '5.5.4';
+        const VERSION = '5.5.5';
 
         /**
 		 * @var string

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -434,7 +434,6 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
          **/
         public function user_related_orders_actions($actions, $order)
         {
-
             //ensure order really needs to be paid
             if (isset($actions['pay']) && $order->needs_payment()) {
                 if ($bill_id = $order->get_meta('vindi_wc_bill_id')) {


### PR DESCRIPTION
## Problemas

1. Após comprar o usuário só tem acesso ao boleto na página de obrigado ou via e-mails de cobrança da Vindi.
2. Nos pedidos de renovação o usuário não tem acesso ao boleto pelo site. Somente pelo e-mail de cobrança da Vindi.


## Motivação
Permitir ao usuário fazer download do boleto na sua área de usuário do site, seja um pedido novo ou pedido de renovação.

## Solução Proposta

1. Foi adicionado o botão de baixar boleto na área de pedidos e assinaturas.
2. Foi adicionado nos pedidos de renovação o meta com a url do boleto, disparado pelo webhook de bill_created

