### PR TITLE
Add settings for Semaphore CI 2.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,3 @@
-# Documentação sobre Semaphore 2.0 com Docker:
-# https://docs.semaphoreci.com/article/78-working-with-docker-images
 version: v1.0
 name: WooComerce
 agent:
@@ -13,8 +11,14 @@ blocks:
         - name: Setup
           commands:
             - docker network create webproxy
-            - docker-compose up -d #&& sleep 20
-            - docker cp wordpress_db:/docker-entrypoint-initdb.d/wordpress.sql dump.sql
-            - docker cp dump.sql vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/tests/_data/
-            - docker cp .env vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/
+            - docker-compose up -d && sleep 20
+            - 'docker cp wordpress_db:/docker-entrypoint-initdb.d/wordpress.sql dump.sql'
+            - 'docker cp dump.sql vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/tests/_data/'
+            - 'docker cp .env vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/'
+            - docker exec -it vindi.local composer test
+  - name: Test
+    task:
+      jobs:
+        - name: Test
+          commands:
             - docker exec -it vindi.local composer test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,8 +13,7 @@ blocks:
         - name: Setup
           commands:
             - docker network create webproxy
-            - docker-compose up -d #&& sleep 20
+            - docker-compose up -d 
             - docker cp wordpress_db:/docker-entrypoint-initdb.d/wordpress.sql dump.sql
             - docker cp dump.sql vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/tests/_data/
-            - docker cp .env vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/
             - docker exec -it vindi.local composer test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,12 +10,12 @@ blocks:
       jobs:
         - name: Setup
           commands:
-            - docker network create webproxy
-            - docker-compose up -d && sleep 20
+            - checkout
+            - cache restore
+            - docker network create webproxy && docker-compose up -d && sleep 20
             - 'docker cp wordpress_db:/docker-entrypoint-initdb.d/wordpress.sql dump.sql'
             - 'docker cp dump.sql vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/tests/_data/'
             - 'docker cp .env vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/'
-            - docker exec -it vindi.local composer test
   - name: Test
     task:
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,20 @@
+# Documentação sobre Semaphore 2.0 com Docker:
+# https://docs.semaphoreci.com/article/78-working-with-docker-images
+version: v1.0
+name: WooComerce
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Setup
+    task:
+      jobs:
+        - name: Setup
+          commands:
+            - docker network create webproxy
+            - docker-compose up -d #&& sleep 20
+            - docker cp wordpress_db:/docker-entrypoint-initdb.d/wordpress.sql dump.sql
+            - docker cp dump.sql vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/tests/_data/
+            - docker cp .env vindi.local:/var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions/
+            - docker exec -it vindi.local composer test

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,1 @@
+API_KEY=digite aqui a chave API


### PR DESCRIPTION
## Motivação :muscle:

Habilitar o projeto para usar a versão 2.0 do Semaphore CI conforme a issue #144 

## Solução proposta :wrench:

Criar arquivo de configuração (YAML) do serviço no projeto

## Como testar :policeman:

Abrir a intrface 2.0 do Semaphore e fazer o build.

## Riscos :warning:

Sem riscos

## Impactos previstos :boom:

Sem impactos

## Requisitos para deploy :game_die:

Ter a entrada do projeto no Semaphore 2.0 criada