### PR TITLE
Adiciona validação para assinatura Variável no carrinho

### DIFF
--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -402,7 +402,7 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 
         function is_cart_item_subscription($cart_item)
         {
-            $subscriptions_types = array('subscription' , 'variable-subscription');
+            $subscriptions_types = array('subscription', 'variable-subscription');
             return in_array($cart_item['data']->product_type, $subscriptions_types);
         }
 
@@ -416,15 +416,13 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 			if (empty($cart_items))
 				return $valid;
 
-            if ($this->is_new_product_subscription($product)) {
-                
+            if ($this->is_new_product_subscription($product)) {               
                 $product_vindi_subscription_plan_meta = get_post_meta($product->post->ID, 'vindi_subscription_plan');
                 $product_vindi_subscription_plan_id   = (int) end($product_vindi_subscription_plan_meta);
 
                 foreach($cart_items as $item)
                 {
                     if ($this->is_cart_item_subscription($item)) {
-
                         $item_vindi_subscription_plan_meta = get_post_meta($item['data']->post->ID, 'vindi_subscription_plan');
                         $item_vindi_subscription_plan_id   = (int) end($item_vindi_subscription_plan_meta);
 

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -395,24 +395,35 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 		 *
 		 * @return bool
 		 */
-		public function validate_add_to_cart($valid, $product_id, $quantity)
+        public function is_new_product_subscription($product)
         {
+            return $product->is_type('subscription') || $product->is_type('variable-subscription');
+        }
+
+        function is_cart_item_subscription($cart_item)
+        {
+            $subscriptions_types = array('subscription' , 'variable-subscription');
+            return in_array($cart_item['data']->product_type, $subscriptions_types);
+        }
+
+		public function validate_add_to_cart($valid, $product_id, $quantity)
+        {    
             $cart       = $this->settings->woocommerce->cart;
-			$cart_items = $cart->get_cart();
-
-			$product = wc_get_product($product_id);
-
+            $cart_items = $cart->get_cart();
+            
+            $product = wc_get_product($product_id);
+            
 			if (empty($cart_items))
 				return $valid;
 
-            if ($product->is_type('subscription') || $product->is_type('variable-subscription') ) {
-
+            if ($this->is_new_product_subscription($product)) {
+                
                 $product_vindi_subscription_plan_meta = get_post_meta($product->post->ID, 'vindi_subscription_plan');
                 $product_vindi_subscription_plan_id   = (int) end($product_vindi_subscription_plan_meta);
 
                 foreach($cart_items as $item)
                 {
-                    if ('subscription' || 'variable-subscription' === $item['data']->product_type) {
+                    if ($this->is_cart_item_subscription($item)) {
 
                         $item_vindi_subscription_plan_meta = get_post_meta($item['data']->post->ID, 'vindi_subscription_plan');
                         $item_vindi_subscription_plan_id   = (int) end($item_vindi_subscription_plan_meta);

--- a/vindi-woocommerce-subscriptions.php
+++ b/vindi-woocommerce-subscriptions.php
@@ -405,14 +405,14 @@ if (! class_exists('Vindi_WooCommerce_Subscriptions'))
 			if (empty($cart_items))
 				return $valid;
 
-            if ($product->is_type('subscription')) {
+            if ($product->is_type('subscription') || $product->is_type('variable-subscription') ) {
 
                 $product_vindi_subscription_plan_meta = get_post_meta($product->post->ID, 'vindi_subscription_plan');
                 $product_vindi_subscription_plan_id   = (int) end($product_vindi_subscription_plan_meta);
 
                 foreach($cart_items as $item)
                 {
-                    if ('subscription' === $item['data']->product_type) {
+                    if ('subscription' || 'variable-subscription' === $item['data']->product_type) {
 
                         $item_vindi_subscription_plan_meta = get_post_meta($item['data']->post->ID, 'vindi_subscription_plan');
                         $item_vindi_subscription_plan_id   = (int) end($item_vindi_subscription_plan_meta);


### PR DESCRIPTION
closes #133

## Motivação
Ao adicionar 2 assinaturas variáveis de planos diferentes no carrinho não havia bloqueio para está ação pelo plugin, deste modo os clientes podiam adicionar uma assinatura anual e uma mensal que levaria o cliente ao erro visto que será utilizado somente 1 plano para os produtos adicionados no carrinho.   

## Solução Proposta
Adicionar junto a validação no carrinho para produtos do tipo **assinatura** o tipo de produto **assinatura variável**. 
