### PR TITLE
Corrige o parcelamento para pagamentos manuais

### DIFF
--- a/includes/class-vindi-creditcard-gateway.php
+++ b/includes/class-vindi-creditcard-gateway.php
@@ -144,7 +144,12 @@ class Vindi_CreditCard_Gateway extends Vindi_Base_Gateway
      */
     public function payment_fields()
     {
-        $total      = $this->container->woocommerce->cart->total;
+        $total = WC()->cart->prices_include_tax ? floatval(WC()->cart->cart_contents_total + WC()->cart->tax_total) : floatval(WC()->cart->cart_contents_total);
+
+        if(isset($_GET['pay_for_order'])){
+            $total = floatval(WC_Payment_Gateway::get_order_total());
+        }
+        
         $max_times  = $this->get_order_max_installments($total);
 
         if ($max_times > 1) {


### PR DESCRIPTION
No caso de pagamentos manuais (pedidos com status de pagamento pendente), o total deve ser obtido nesse caso do WC_Payment_Gateway por se tratar de um pedido fechado. O tratamento é feito através da identificação do pay_for_order no $_GET. Atualização contendo tratamento para casos em que taxas estão habilitadas.

