### PR TITLE
Corrige cliente incorreto na transação

### DIFF
--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -94,6 +94,10 @@ class Vindi_Payment
         $currentUser = wp_get_current_user();
         $email       = $this->order->get_billing_email();
 
+        if(isset($_GET['pay_for_order'])){
+            $currentUser = get_user_by('ID', $this->order->get_user_id());
+        }
+        
         $address = array(
             'street'             => $this->order->get_billing_address_1(),
             'number'             => $this->order->get_meta( '_billing_number' ),


### PR DESCRIPTION
No caso do pagamento avulso (pagamento pendente com link de pagamento enviado para o cliente, sem obrigatoriedade de login), o usuário a ser obtido deve ser o dono do pedido, não o usuário logado.

Casos de uso: 

Cliente liga, faz o pedido por telefone e solicita que o operacional do e-commerce faça o pagamento. Neste caso, o pedido é criado pelo painel e pago pelo link de pagamento diretamente, não no fluxo comum do e-commerce e assim, seria registrado como "cliente" na Vindi o usuário logado (funcionário do operacional) sendo que, o importante neste caso é o registro do usuário do pedido.

Basicamente, a relevância em termo de "cliente" para pedidos com "pay_for_order" (sem necessidade de login) deve ser o cliente dono do pedido, não o pagante.