### PR TITLE
Corrige bill_items inválido quando a quantidade não é um valor inteiro

### DIFF
--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -487,7 +487,7 @@ class Vindi_Payment
         $item          = $this->container->api->find_or_create_product("Cupom de desconto", 'wc-discount');
         $discount_item = array(
             'type'     => 'discount',
-            'vindi_id' => $item['id'],
+            'vindi_id' => ceil($item['id']),
             'price'    => (float) $total_discount * -1,
             'qty'      => 1
         );

--- a/includes/class-vindi-payment.php
+++ b/includes/class-vindi-payment.php
@@ -487,7 +487,7 @@ class Vindi_Payment
         $item          = $this->container->api->find_or_create_product("Cupom de desconto", 'wc-discount');
         $discount_item = array(
             'type'     => 'discount',
-            'vindi_id' => ceil($item['id']),
+            'vindi_id' => $item['id'],
             'price'    => (float) $total_discount * -1,
             'qty'      => 1
         );
@@ -499,7 +499,7 @@ class Vindi_Payment
     {
         $item = array(
             'product_id'        => $order_item['vindi_id'],
-            'quantity'          => $order_item['qty'],
+            'quantity'          => ceil($order_item['qty']),
             'pricing_schema'    => array(
                 'price'             => $order_item['price'],
                 'schema_type'       => 'per_unit'


### PR DESCRIPTION
Para produtos em que uma caixa, por exemplo, representa 1.5 metros quadrados e o múltiplo de venda ocorre em cima dessa quantidade, o módulo não consegue processar o pagamento pelo fato de que a API apenas aceita um número inteiro na quantidade do produto.

## O que mudou
_Descreva em poucas palavras o que muda para usuários do projeto. Esta descrição será utilizada para publicar o changelog._

## Motivação
_Descreva a motivação deste PR. Explique qual é o problema que queremos resolver._

## Solução proposta
_Descreva a solução proposta para resolver o problema mencionado na seção "Motivação", incluindo os detalhes técnicos necessários para entender essa solução._

## Como testar
_Descreva detalhadamente, passo a passo, como testar este PR. Especifique requisitos, como por exemplo, acesso prévio em alguma ferramenta._
